### PR TITLE
feat: add last_order sensor with per-SKU breakdown and receipt grouping

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -6,9 +6,12 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v6"
       - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -1,6 +1,11 @@
 name: Python package
 
-on: [push]
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -8,17 +13,15 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.13]
+        python-version: ["3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Set PY env
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+          cache: "pip"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -7,10 +7,14 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-hacs:
     runs-on: "ubuntu-latest"
     steps:
+      - uses: "actions/checkout@v6"
       - name: HACS validation
         uses: "hacs/action@main"
         with:

--- a/custom_components/etsyapp/coordinator.py
+++ b/custom_components/etsyapp/coordinator.py
@@ -1,5 +1,6 @@
 """Integration for Etsy shop monitoring coordinator."""
 
+from collections import defaultdict
 from datetime import timedelta, datetime
 import asyncio
 import json
@@ -566,9 +567,24 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
 
             # Build detailed transaction data for the new orders
             transactions = data.get("transactions", [])
-            new_transactions = [
-                build_transaction_detail(t)
-                for t in transactions[:new_order_count]
+            new_transactions = []
+            receipt_groups = defaultdict(list)
+            for t in transactions[:new_order_count]:
+                detail = build_transaction_detail(t)
+                new_transactions.append(detail)
+                # Group by receipt_id for per-order access
+                receipt_id = t.get("receipt_id")
+                key = str(receipt_id) if receipt_id else str(t.get("transaction_id", ""))
+                receipt_groups[key].append(detail)
+
+            receipts = [
+                {
+                    "receipt_id": rid,
+                    "buyer_user_id": items[0].get("buyer_user_id"),
+                    "item_count": len(items),
+                    "items": items,
+                }
+                for rid, items in receipt_groups.items()
             ]
 
             self._hass.bus.async_fire(
@@ -578,6 +594,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                     "shop_name": shop.get("shop_name"),
                     "new_orders": new_order_count,
                     "orders": new_transactions,
+                    "receipts": receipts,
                 }
             )
         self._prev_transactions_count = current_transactions_count

--- a/custom_components/etsyapp/manifest.json
+++ b/custom_components/etsyapp/manifest.json
@@ -12,5 +12,5 @@
         "requests>=2.32.3",
         "python-dateutil>=2.9.0"
     ],
-    "version": "1.1.5"
+    "version": "1.2.0"
 }

--- a/custom_components/etsyapp/sensor.py
+++ b/custom_components/etsyapp/sensor.py
@@ -1,5 +1,6 @@
 """Integration for Etsy shop monitoring sensors."""
 
+from collections import defaultdict
 from datetime import datetime
 import logging
 from typing import Any
@@ -40,6 +41,7 @@ async def async_setup_entry(
             EtsyShopInfo(coordinator),
             EtsyActiveListings(coordinator),
             EtsyRecentOrders(coordinator),
+            EtsyLastOrder(coordinator),
             EtsyShopStats(coordinator),
         ],
         update_before_add=True,
@@ -258,7 +260,7 @@ class EtsyRecentOrders(CoordinatorEntity, SensorEntity):
 
             for transaction in transactions[:self._display_limit]:
                 summary = build_transaction_detail(transaction)
-                total_revenue += summary["price_amount"]
+                total_revenue += summary["price_amount"] * (summary.get("quantity") or 1)
                 transactions_summary.append(summary)
 
             self._hass_custom_attributes = {
@@ -267,6 +269,116 @@ class EtsyRecentOrders(CoordinatorEntity, SensorEntity):
                 "total_recent_revenue": round(total_revenue, 2),
                 "currency_code": transactions_summary[0]["price_currency"] if transactions_summary else "USD",
             }
+
+        self.async_write_ha_state()
+
+
+class EtsyLastOrder(CoordinatorEntity, SensorEntity):
+    """Representation of sensor that shows the most recent order with per-SKU breakdown."""
+
+    def __init__(self, coordinator: EtsyUpdateCoordinator) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._hass_custom_attributes = {}
+        self._attr_name = "Etsy Last Order"
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_last_order"
+        self._globalid = "etsy_last_order"
+        self._attr_icon = "mdi:cart"
+        self._attr_state = None
+        # Associate with device
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, coordinator.config_entry.entry_id)},
+        }
+
+    @property
+    def state(self) -> Any:
+        """Return the current state of the sensor."""
+        return self._attr_state
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return self._hass_custom_attributes
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        etsy_data = self.coordinator.data
+
+        if not etsy_data:
+            self._attr_state = 0
+            self._attr_icon = "mdi:cart-off"
+            self._hass_custom_attributes = {}
+            self.async_write_ha_state()
+            return
+
+        transactions = etsy_data.get("transactions", [])
+        if not transactions:
+            self._attr_state = 0
+            self._attr_icon = "mdi:cart-off"
+            self._hass_custom_attributes = {}
+            self.async_write_ha_state()
+            return
+
+        # Group transactions by receipt_id to identify items from the same order
+        grouped = defaultdict(list)
+        for txn in transactions:
+            receipt_id = txn.get("receipt_id")
+            if receipt_id:
+                grouped[str(receipt_id)].append(txn)
+            else:
+                # Fallback: treat each transaction as its own order
+                grouped[str(txn.get("transaction_id", ""))].append(txn)
+
+        # Find the most recent order group by max created_timestamp
+        most_recent_receipt = None
+        most_recent_timestamp = 0
+        for receipt_id, txns in grouped.items():
+            group_timestamp = max(
+                t.get("created_timestamp", 0) for t in txns
+            )
+            if group_timestamp > most_recent_timestamp:
+                most_recent_timestamp = group_timestamp
+                most_recent_receipt = receipt_id
+
+        if not most_recent_receipt:
+            self._attr_state = 0
+            self._attr_icon = "mdi:cart-off"
+            self._hass_custom_attributes = {}
+            self.async_write_ha_state()
+            return
+
+        order_transactions = grouped[most_recent_receipt]
+
+        # Build per-item details
+        items = []
+        order_total = 0
+        total_quantity = 0
+        for txn in order_transactions:
+            detail = build_transaction_detail(txn)
+            items.append(detail)
+            qty = detail.get("quantity") or 1
+            order_total += detail["price_amount"] * qty
+            total_quantity += qty
+
+        # Get order-level info from the first transaction
+        first_item = items[0]
+        order_date = min(
+            (item["created_date"] for item in items if item.get("created_date")),
+            default=None,
+        )
+
+        self._attr_state = total_quantity
+        self._attr_icon = "mdi:cart"
+
+        self._hass_custom_attributes = {
+            "receipt_id": most_recent_receipt,
+            "buyer_user_id": first_item.get("buyer_user_id"),
+            "order_total": round(order_total, 2),
+            "currency_code": first_item.get("price_currency", "USD"),
+            "order_date": order_date,
+            "item_count": len(items),
+            "items": items,
+        }
 
         self.async_write_ha_state()
 
@@ -327,7 +439,8 @@ class EtsyShopStats(CoordinatorEntity, SensorEntity):
             for transaction in transactions:
                 price = transaction.get("price", {})
                 if price.get("amount"):
-                    recent_revenue += float(price["amount"]) / 100
+                    qty = transaction.get("quantity") or 1
+                    recent_revenue += float(price["amount"]) / 100 * qty
 
             self._hass_custom_attributes = {
                 "total_sales": sale_count,

--- a/custom_components/etsyapp/services.py
+++ b/custom_components/etsyapp/services.py
@@ -133,6 +133,14 @@ async def async_register_services(hass: HomeAssistant):
                     "shop_name": shop_name,
                     "new_orders": 1,
                     "orders": [order_detail],
+                    "receipts": [
+                        {
+                            "receipt_id": order_detail.get("receipt_id", "0000000000"),
+                            "buyer_user_id": order_detail.get("buyer_user_id", "0000000000"),
+                            "item_count": 1,
+                            "items": [order_detail],
+                        }
+                    ],
                 }
 
             elif event_type == "new_review":

--- a/custom_components/etsyapp/utils.py
+++ b/custom_components/etsyapp/utils.py
@@ -36,6 +36,7 @@ def build_transaction_detail(transaction: dict) -> dict:
 
     return {
         "transaction_id": str(transaction.get("transaction_id", "")),
+        "receipt_id": str(transaction.get("receipt_id", "")),
         "title": transaction.get("title"),
         "listing_id": str(transaction.get("listing_id", "")),
         "buyer_user_id": str(transaction.get("buyer_user_id", "")),

--- a/tests/fixtures/etsy_shop_data.json
+++ b/tests/fixtures/etsy_shop_data.json
@@ -49,6 +49,7 @@
   "transactions": [
     {
       "transaction_id": 111111111,
+      "receipt_id": 5550001,
       "title": "Handmade Leather Wallet",
       "listing_id": 123456789,
       "buyer_user_id": 22222222,
@@ -62,7 +63,23 @@
       "updated_timestamp": 1693843200
     },
     {
+      "transaction_id": 222222222,
+      "receipt_id": 5550001,
+      "title": "Matching Leather Keychain",
+      "listing_id": 123456790,
+      "buyer_user_id": 22222222,
+      "quantity": 2,
+      "price": {
+        "amount": 1200,
+        "divisor": 100,
+        "currency_code": "USD"
+      },
+      "created_timestamp": 1693843200,
+      "updated_timestamp": 1693843200
+    },
+    {
       "transaction_id": 333333333,
+      "receipt_id": 5550002,
       "title": "Custom Wood Sign",
       "listing_id": 987654321,
       "buyer_user_id": 44444444,
@@ -77,6 +94,6 @@
     }
   ],
   "listings_count": 2,
-  "transactions_count": 2,
+  "transactions_count": 3,
   "last_updated": "2023-09-04 10:00:00.000000"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -87,9 +87,9 @@ async def test_etsy_update_coordinator(hass, aioclient_mock):
     assert coordinator.last_update_success
     assert coordinator.data['shop']['shop_name'] == "TestEtsyShop"
     assert coordinator.data['listings_count'] == 2
-    assert coordinator.data['transactions_count'] == 2
+    assert coordinator.data['transactions_count'] == 3
     assert len(coordinator.data['listings']) == 2
-    assert len(coordinator.data['transactions']) == 2
+    assert len(coordinator.data['transactions']) == 3
 
 
 @pytest.mark.asyncio
@@ -218,7 +218,7 @@ async def test_token_refresh_returns_cached_data(hass, aioclient_mock):
         "listings": etsy_data["listings"],
         "transactions": etsy_data["transactions"],
         "listings_count": 2,
-        "transactions_count": 2,
+        "transactions_count": 3,
         "last_updated": "2025-01-01 00:00:00.000000"
     }
     

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -6,10 +6,11 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock
 from pathlib import Path
 from custom_components.etsyapp.sensor import (
-    EtsyShopInfo, 
-    EtsyActiveListings, 
-    EtsyRecentOrders, 
-    EtsyShopStats
+    EtsyShopInfo,
+    EtsyActiveListings,
+    EtsyRecentOrders,
+    EtsyLastOrder,
+    EtsyShopStats,
 )
 from custom_components.etsyapp.coordinator import EtsyUpdateCoordinator
 
@@ -145,12 +146,12 @@ async def test_etsy_recent_orders_sensor():
     sensor._handle_coordinator_update()
 
     # Assert the state and attributes
-    assert sensor.state == 2  # transactions_count
-    assert sensor.extra_state_attributes["transactions_count"] == 2
-    assert len(sensor.extra_state_attributes["recent_transactions"]) == 2
-    assert sensor.extra_state_attributes["total_recent_revenue"] == 70.0  # 25.00 + 45.00
+    assert sensor.state == 3  # transactions_count
+    assert sensor.extra_state_attributes["transactions_count"] == 3
+    assert len(sensor.extra_state_attributes["recent_transactions"]) == 3
+    assert sensor.extra_state_attributes["total_recent_revenue"] == 94.0  # 25.00*1 + 12.00*2 + 45.00*1
     assert sensor.extra_state_attributes["currency_code"] == "USD"
-    assert sensor._attr_icon == "mdi:numeric-2-circle"
+    assert sensor._attr_icon == "mdi:numeric-3-circle"
     
     # Check that transaction IDs and dates are properly formatted
     first_transaction = sensor.extra_state_attributes["recent_transactions"][0]
@@ -188,6 +189,60 @@ async def test_etsy_recent_orders_sensor_empty():
 
 
 @pytest.mark.asyncio
+async def test_etsy_last_order_sensor():
+    """Test the EtsyLastOrder sensor groups transactions by receipt_id."""
+    # Mock the coordinator
+    mock_coordinator = AsyncMock(spec=EtsyUpdateCoordinator)
+    mock_coordinator.data = etsy_data
+    mock_coordinator.config_entry = AsyncMock()
+    mock_coordinator.config_entry.entry_id = "test_entry_id"
+    mock_coordinator.config_entry.options = {}
+
+    # Initialize the sensor
+    sensor = EtsyLastOrder(mock_coordinator)
+    sensor.async_write_ha_state = Mock()  # Mock to avoid requiring hass instance
+
+    # Trigger coordinator update handler
+    sensor._handle_coordinator_update()
+
+    # The most recent order is receipt_id 5550001 (timestamp 1693843200)
+    # It has 2 transactions: Wallet (qty 1, $25) + Keychain (qty 2, $12)
+    assert sensor.state == 3  # total quantity: 1 + 2
+    assert sensor.extra_state_attributes["receipt_id"] == "5550001"
+    assert sensor.extra_state_attributes["buyer_user_id"] == "22222222"
+    assert sensor.extra_state_attributes["item_count"] == 2  # 2 distinct SKUs
+    assert sensor.extra_state_attributes["order_total"] == 49.0  # 25 + (12 * 2)
+    assert sensor.extra_state_attributes["currency_code"] == "USD"
+    assert len(sensor.extra_state_attributes["items"]) == 2
+    assert sensor._attr_icon == "mdi:cart"
+
+    # Verify item details
+    items = sensor.extra_state_attributes["items"]
+    titles = [item["title"] for item in items]
+    assert "Handmade Leather Wallet" in titles
+    assert "Matching Leather Keychain" in titles
+
+
+@pytest.mark.asyncio
+async def test_etsy_last_order_sensor_empty():
+    """Test the EtsyLastOrder sensor with no transactions."""
+    mock_coordinator = AsyncMock(spec=EtsyUpdateCoordinator)
+    mock_coordinator.data = empty_data
+    mock_coordinator.config_entry = AsyncMock()
+    mock_coordinator.config_entry.entry_id = "test_entry_id"
+    mock_coordinator.config_entry.options = {}
+
+    sensor = EtsyLastOrder(mock_coordinator)
+    sensor.async_write_ha_state = Mock()
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.state == 0
+    assert sensor._attr_icon == "mdi:cart-off"
+    assert sensor.extra_state_attributes == {}
+
+
+@pytest.mark.asyncio
 async def test_etsy_shop_stats_sensor():
     """Test the EtsyShopStats sensor with valid data."""
     # Mock the coordinator
@@ -208,10 +263,10 @@ async def test_etsy_shop_stats_sensor():
     assert sensor.state == "1500 total sales"
     assert sensor.extra_state_attributes["total_sales"] == 1500
     assert sensor.extra_state_attributes["active_listings"] == 2
-    assert sensor.extra_state_attributes["recent_transactions"] == 2
+    assert sensor.extra_state_attributes["recent_transactions"] == 3
     assert sensor.extra_state_attributes["total_views"] == 430
     assert sensor.extra_state_attributes["total_favorites"] == 20
-    assert sensor.extra_state_attributes["recent_revenue"] == 70.0
+    assert sensor.extra_state_attributes["recent_revenue"] == 94.0
     assert sensor.extra_state_attributes["shop_currency"] == "USD"
     assert sensor.extra_state_attributes["average_rating"] == 4.8
     assert sensor.extra_state_attributes["total_reviews"] == 125
@@ -261,9 +316,10 @@ async def test_all_sensors_with_partial_data():
     # Test all sensors
     sensors = [
         EtsyShopInfo(mock_coordinator),
-        EtsyActiveListings(mock_coordinator), 
+        EtsyActiveListings(mock_coordinator),
         EtsyRecentOrders(mock_coordinator),
-        EtsyShopStats(mock_coordinator)
+        EtsyLastOrder(mock_coordinator),
+        EtsyShopStats(mock_coordinator),
     ]
 
     for sensor in sensors:


### PR DESCRIPTION
- New EtsyLastOrder sensor groups transactions by receipt_id to show the most recent order with individual items, quantity, and totals
- Add receipts field to new_order event for per-order grouping (backward compatible - existing orders field unchanged)
- Fix revenue calculations to account for quantity across all sensors
- Update fire_test_event service to include receipts in test payload

Related to #16 