### PR TITLE
feat: enrich Last Order with buyer name and net payout

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Each integration entry is named `ShopName (ShopID) - Direct` or `ShopName (ShopI
 | Etsy Shop Info | Shop name | Shop ID, currency, creation date, announcement, sale message |
 | Etsy Active Listings | Active listing count | Recent listings, total views, total favorites |
 | Etsy Recent Orders | Recent transaction count | Transaction details, recent revenue, buyer info |
-| Etsy Last Order | Last order quantity | Item title, price, variations, buyer info |
+| Etsy Last Order | Last order item quantity | Buyer name, order totals (subtotal, grandtotal, shipping, tax), net payout (`amount_net`) after Etsy fees, per-item breakdown, buyer message, gift info, ship/paid status |
 | Etsy Shop Statistics | Total sales count | Active listings, views, favorites, revenue, ratings |
 
 ## Sample dashboard cards
@@ -104,8 +104,16 @@ automation:
     action:
       - service: notify.mobile_app
         data:
-          message: You have a new Etsy order!
+          message: >-
+            New order from {{ trigger.event.data.receipts[0].buyer_name }} —
+            {{ trigger.event.data.receipts[0].currency_code }}{{ trigger.event.data.receipts[0].grandtotal }}
 ```
+
+The `receipts[]` entries in the `new_order` event carry the same fields as the `etsy_last_order` sensor attributes (buyer name, totals, items, message from buyer, etc.).
+
+### Proxy mode
+
+Proxy mode requires proxy version **1.1.0 or newer** for the receipts/payments endpoints. Older proxies fall back to the transactions-only path automatically; buyer name and order totals will not be populated until the proxy is upgraded.
 
 ## Requirements
 

--- a/custom_components/etsyapp/coordinator.py
+++ b/custom_components/etsyapp/coordinator.py
@@ -29,7 +29,7 @@ from .const import (
     CONF_HMAC_SECRET,
 )
 from .hmac_client import HMACClient
-from .utils import build_transaction_detail
+from .utils import build_receipt_summary, build_transaction_detail
 
 _LOGGER = logging.getLogger(__name__)
 type EtsyConfigEntry = ConfigEntry[EtsyUpdateCoordinator]
@@ -47,6 +47,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
         # Track previous state for change detection
         self._prev_transactions_count = 0
         self._prev_review_count = 0
+        self._prev_receipt_ids: set[str] = set()
         # Rate limiting with exponential backoff
         self._retry_count = 0
         self._max_retries = 5
@@ -228,15 +229,36 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
             # Now fetch shop data with HMAC signatures
             shop_info = await self._fetch_shop_info_proxy()
             listings_data = await self._fetch_listings_proxy()
-            transactions_data = await self._fetch_transactions_proxy()
-            
+
+            # Try receipts first; fall back to /transactions if the proxy
+            # hasn't been upgraded yet (one-release transition window).
+            receipts_data = await self._fetch_receipts_proxy()
+            if receipts_data is None:
+                _LOGGER.debug("Proxy /receipts unavailable, falling back to /transactions")
+                transactions_data = await self._fetch_transactions_proxy()
+                receipts = []
+                flattened_transactions = transactions_data.get("results", []) or []
+                transactions_count = transactions_data.get(
+                    "count", len(flattened_transactions)
+                )
+                last_payment = None
+            else:
+                receipts = receipts_data.get("results", []) or []
+                flattened_transactions = []
+                for receipt in receipts:
+                    flattened_transactions.extend(receipt.get("transactions") or [])
+                transactions_count = len(flattened_transactions)
+                last_payment = await self._fetch_last_payment_proxy(receipts)
+
             proxy_data = {
-                "shop": shop_info,  # Changed from "shop_info" to "shop" to match sensor expectations
+                "shop": shop_info,
                 "listings": listings_data.get("results", []),
-                "listings_count": listings_data.get("count", 0),  # Changed from "active_listings_count" to "listings_count"
-                "transactions": transactions_data.get("results", []),
-                "transactions_count": transactions_data.get("count", len(transactions_data.get("results", []))),
-                "last_updated": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),  # Match format with direct mode
+                "listings_count": listings_data.get("count", 0),
+                "transactions": flattened_transactions,
+                "receipts": receipts,
+                "last_payment": last_payment,
+                "transactions_count": transactions_count,
+                "last_updated": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
             }
             
             # Cache successful data for use during temporary failures
@@ -291,14 +313,14 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
         return await response.json()
     
     async def _fetch_transactions_proxy(self) -> dict:
-        """Fetch transactions via proxy."""
+        """Fetch transactions via proxy (legacy fallback for older proxies)."""
         path = f"/api/v1/shops/{self.shop_id}/transactions"
         headers = self.hmac_client.get_headers_with_signature(
             method="GET",
             path=path,
             api_key=self.proxy_api_key
         )
-        
+
         response = await self.session.get(
             f"{self.proxy_url}{path}",
             headers=headers,
@@ -308,6 +330,76 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.warning("Failed to get transactions: %s", text)
             return {"results": []}
         return await response.json()
+
+    async def _fetch_receipts_proxy(self) -> dict | None:
+        """Fetch receipts via proxy. Returns None if the proxy doesn't support
+        the endpoint yet (404), signalling a fallback to /transactions."""
+        path = f"/api/v1/shops/{self.shop_id}/receipts"
+        headers = self.hmac_client.get_headers_with_signature(
+            method="GET",
+            path=path,
+            api_key=self.proxy_api_key,
+        )
+        params = {
+            "limit": API_FETCH_LIMIT,
+            "was_paid": "true",
+        }
+        response = await self.session.get(
+            f"{self.proxy_url}{path}",
+            headers=headers,
+            params=params,
+        )
+        if response.status == 404:
+            return None
+        if response.status != 200:
+            text = await response.text()
+            _LOGGER.warning("Failed to get receipts: %s", text)
+            return {"results": []}
+        data = await response.json()
+        # Sort client-side — Etsy's /receipts default order isn't documented.
+        results = data.get("results") or []
+        results.sort(
+            key=lambda r: r.get("created_timestamp") or 0,
+            reverse=True,
+        )
+        data["results"] = results
+        return data
+
+    async def _fetch_last_payment_proxy(self, receipts: list[dict]) -> dict | None:
+        """Fetch the payment for the most recent receipt via proxy. Best-effort."""
+        if not receipts:
+            return None
+        receipt_id = receipts[0].get("receipt_id")
+        if not receipt_id:
+            return None
+        path = f"/api/v1/shops/{self.shop_id}/receipts/{receipt_id}/payments"
+        headers = self.hmac_client.get_headers_with_signature(
+            method="GET",
+            path=path,
+            api_key=self.proxy_api_key,
+        )
+        try:
+            response = await self.session.get(
+                f"{self.proxy_url}{path}",
+                headers=headers,
+            )
+            if response.status != 200:
+                _LOGGER.debug(
+                    "Proxy payment fetch skipped for receipt %s (status %s)",
+                    receipt_id,
+                    response.status,
+                )
+                return None
+            data = await response.json()
+            results = data.get("results") if isinstance(data, dict) else data
+            if isinstance(results, list) and results:
+                return results[0]
+            if isinstance(data, dict) and data.get("amount_net"):
+                return data
+            return None
+        except Exception as err:
+            _LOGGER.debug("Proxy payment fetch failed for receipt %s: %s", receipt_id, err)
+            return None
     
     async def _fetch_direct(self) -> dict[str, Any]:
         """Fetch data directly from Etsy API with automatic token refresh."""
@@ -444,29 +536,53 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
             listings_response.raise_for_status()
             listings_data = await listings_response.json()
             
-            # Get recent transactions
-            transactions_url = f"{ETSY_API_BASE}/shops/{self.shop_id}/transactions"
-            transactions_params = {"limit": API_FETCH_LIMIT}
-            transactions_response = await self.session.get(
-                transactions_url, headers=headers, params=transactions_params
+            # Get recent receipts (replaces /transactions — receipts embed their
+            # transactions array and additionally carry buyer name + order totals).
+            # Etsy's /receipts endpoint doesn't accept sort_on/sort_order params
+            # and doesn't document its default order, so we sort client-side
+            # to guarantee receipts[0] is the most recent.
+            receipts_url = f"{ETSY_API_BASE}/shops/{self.shop_id}/receipts"
+            receipts_params = {
+                "limit": API_FETCH_LIMIT,
+                "was_paid": "true",
+            }
+            receipts_response = await self.session.get(
+                receipts_url, headers=headers, params=receipts_params
             )
-            
-            # Check for rate limiting  
-            if transactions_response.status == 429:
-                retry_after = transactions_response.headers.get("Retry-After", "60")
-                _LOGGER.warning("Etsy API rate limit hit on transactions. Retry after %s seconds", retry_after)
+
+            if receipts_response.status == 429:
+                retry_after = receipts_response.headers.get("Retry-After", "60")
+                _LOGGER.warning("Etsy API rate limit hit on receipts. Retry after %s seconds", retry_after)
                 raise UpdateFailed(f"Rate limit exceeded (429). Retry after {retry_after} seconds")
-            
-            transactions_response.raise_for_status()
-            transactions_data = await transactions_response.json()
-            
+
+            receipts_response.raise_for_status()
+            receipts_data = await receipts_response.json()
+            receipts = receipts_data.get("results", []) or []
+            receipts.sort(
+                key=lambda r: r.get("created_timestamp") or 0,
+                reverse=True,
+            )
+
+            # Flatten transactions out of receipts to preserve data["transactions"]
+            # for EtsyRecentOrders, EtsyShopStats and services.py.
+            flattened_transactions = []
+            for receipt in receipts:
+                flattened_transactions.extend(receipt.get("transactions") or [])
+
+            # Best-effort fetch of payment for the most recent receipt only —
+            # /payments is one call per receipt, and only EtsyLastOrder
+            # surfaces amount_net.
+            last_payment = await self._fetch_last_payment_direct(receipts, headers)
+
             # Combine data
             combined_data = {
                 "shop": shop_data,  # Already extracted above
                 "listings": listings_data.get("results", []),
-                "transactions": transactions_data.get("results", []),
+                "transactions": flattened_transactions,
+                "receipts": receipts,
+                "last_payment": last_payment,
                 "listings_count": listings_data.get("count", 0),
-                "transactions_count": transactions_data.get("count", 0),
+                "transactions_count": len(flattened_transactions),
                 "last_updated": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
             }
             
@@ -480,7 +596,45 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
             raise
         except Exception as err:
             raise UpdateFailed(f"Error fetching data from Etsy API: {err}") from err
-    
+
+    async def _fetch_last_payment_direct(
+        self, receipts: list[dict], headers: dict
+    ) -> dict | None:
+        """Fetch the payment for the most recent receipt. Best-effort.
+
+        amount_net (the seller's net payout after Etsy fees) lives on the
+        payment object, not the receipt. We only fetch it for the latest
+        receipt to keep API usage in check — EtsyLastOrder is the only sensor
+        that surfaces net payout.
+        """
+        if not receipts:
+            return None
+        receipt_id = receipts[0].get("receipt_id")
+        if not receipt_id:
+            return None
+        try:
+            url = f"{ETSY_API_BASE}/shops/{self.shop_id}/receipts/{receipt_id}/payments"
+            response = await self.session.get(url, headers=headers)
+            if response.status != 200:
+                _LOGGER.debug(
+                    "Skipping payment fetch for receipt %s (status %s)",
+                    receipt_id,
+                    response.status,
+                )
+                return None
+            data = await response.json()
+            # Endpoint returns a list (a receipt can have multiple payments,
+            # one per payment method); take the first.
+            results = data.get("results") if isinstance(data, dict) else data
+            if isinstance(results, list) and results:
+                return results[0]
+            if isinstance(data, dict) and data.get("amount_net"):
+                return data
+            return None
+        except Exception as err:
+            _LOGGER.debug("Payment fetch failed for receipt %s: %s", receipt_id, err)
+            return None
+
     async def _manual_token_refresh(self) -> str | None:
         """Manually refresh the OAuth token using the refresh token."""
         try:
@@ -559,33 +713,53 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
         device_id = device.id
         shop = data.get("shop", {})
         
-        # Check for new orders (transactions)
+        # Check for new orders. `new_orders` count is preserved as a delta of
+        # transaction line items (legacy behavior — automations may template
+        # off it). The richer `receipts` payload is built from real receipt
+        # data when available, diffed by receipt_id.
         current_transactions_count = data.get("transactions_count", 0)
+        current_receipts = data.get("receipts") or []
+        current_receipt_ids = {
+            str(r.get("receipt_id")) for r in current_receipts if r.get("receipt_id")
+        }
+
         if current_transactions_count > self._prev_transactions_count and self._prev_transactions_count > 0:
             new_order_count = current_transactions_count - self._prev_transactions_count
-            _LOGGER.debug("New order detected! Count increased from %s to %s", self._prev_transactions_count, current_transactions_count)
+            _LOGGER.debug(
+                "New order detected! Transaction count %s -> %s",
+                self._prev_transactions_count,
+                current_transactions_count,
+            )
 
-            # Build detailed transaction data for the new orders
             transactions = data.get("transactions", [])
-            new_transactions = []
-            receipt_groups = defaultdict(list)
-            for t in transactions[:new_order_count]:
-                detail = build_transaction_detail(t)
-                new_transactions.append(detail)
-                # Group by receipt_id for per-order access
-                receipt_id = t.get("receipt_id")
-                key = str(receipt_id) if receipt_id else str(t.get("transaction_id", ""))
-                receipt_groups[key].append(detail)
-
-            receipts = [
-                {
-                    "receipt_id": rid,
-                    "buyer_user_id": items[0].get("buyer_user_id"),
-                    "item_count": len(items),
-                    "items": items,
-                }
-                for rid, items in receipt_groups.items()
+            new_transactions = [
+                build_transaction_detail(t) for t in transactions[:new_order_count]
             ]
+
+            # Build receipts payload — prefer real receipts diffed by ID,
+            # fall back to client-side grouping when receipt data isn't
+            # present (legacy proxy path).
+            new_receipt_ids = current_receipt_ids - self._prev_receipt_ids
+            if current_receipts and new_receipt_ids:
+                new_receipts = [
+                    build_receipt_summary(r)
+                    for r in current_receipts
+                    if str(r.get("receipt_id")) in new_receipt_ids
+                ]
+            else:
+                receipt_groups: dict[str, list[dict]] = defaultdict(list)
+                for detail in new_transactions:
+                    key = detail.get("receipt_id") or detail.get("transaction_id") or ""
+                    receipt_groups[key].append(detail)
+                new_receipts = [
+                    {
+                        "receipt_id": rid,
+                        "buyer_user_id": items[0].get("buyer_user_id"),
+                        "item_count": len(items),
+                        "items": items,
+                    }
+                    for rid, items in receipt_groups.items()
+                ]
 
             self._hass.bus.async_fire(
                 f"{DOMAIN}_new_order",
@@ -594,10 +768,11 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                     "shop_name": shop.get("shop_name"),
                     "new_orders": new_order_count,
                     "orders": new_transactions,
-                    "receipts": receipts,
+                    "receipts": new_receipts,
                 }
             )
         self._prev_transactions_count = current_transactions_count
+        self._prev_receipt_ids = current_receipt_ids
         
         # Check for new reviews
         current_review_count = shop.get("review_count", 0)

--- a/custom_components/etsyapp/manifest.json
+++ b/custom_components/etsyapp/manifest.json
@@ -12,5 +12,5 @@
         "requests>=2.32.3",
         "python-dateutil>=2.9.0"
     ],
-    "version": "1.2.1"
+    "version": "1.3.0"
 }

--- a/custom_components/etsyapp/manifest.json
+++ b/custom_components/etsyapp/manifest.json
@@ -12,5 +12,5 @@
         "requests>=2.32.3",
         "python-dateutil>=2.9.0"
     ],
-    "version": "1.3.0"
+    "version": "1.3.0-beta.1"
 }

--- a/custom_components/etsyapp/sensor.py
+++ b/custom_components/etsyapp/sensor.py
@@ -22,7 +22,7 @@ from .const import (
     EMPTY_ATTRIBUTES,
 )
 from .coordinator import EtsyConfigEntry, EtsyUpdateCoordinator
-from .utils import build_transaction_detail
+from .utils import build_receipt_summary, build_transaction_detail
 
 PLATFORMS = [Platform.SENSOR]
 _LOGGER = logging.getLogger(__name__)
@@ -305,82 +305,66 @@ class EtsyLastOrder(CoordinatorEntity, SensorEntity):
         etsy_data = self.coordinator.data
 
         if not etsy_data:
-            self._attr_state = 0
-            self._attr_icon = "mdi:cart-off"
-            self._hass_custom_attributes = {}
-            self.async_write_ha_state()
+            self._set_empty()
             return
 
-        transactions = etsy_data.get("transactions", [])
-        if not transactions:
-            self._attr_state = 0
-            self._attr_icon = "mdi:cart-off"
-            self._hass_custom_attributes = {}
-            self.async_write_ha_state()
-            return
-
-        # Group transactions by receipt_id to identify items from the same order
-        grouped = defaultdict(list)
-        for txn in transactions:
-            receipt_id = txn.get("receipt_id")
-            if receipt_id:
-                grouped[str(receipt_id)].append(txn)
-            else:
-                # Fallback: treat each transaction as its own order
-                grouped[str(txn.get("transaction_id", ""))].append(txn)
-
-        # Find the most recent order group by max created_timestamp
-        most_recent_receipt = None
-        most_recent_timestamp = 0
-        for receipt_id, txns in grouped.items():
-            group_timestamp = max(
-                t.get("created_timestamp", 0) for t in txns
+        receipts = etsy_data.get("receipts") or []
+        if receipts:
+            last_payment = etsy_data.get("last_payment")
+            summary = build_receipt_summary(receipts[0], last_payment)
+        else:
+            # Fallback for proxy-skew case: synthesize a receipt by grouping
+            # transactions on receipt_id. No payment data available in this
+            # path, and receipt-level totals are missing — only items_subtotal
+            # and the legacy fields will be populated.
+            summary = self._synthesize_from_transactions(
+                etsy_data.get("transactions") or []
             )
-            if group_timestamp > most_recent_timestamp:
-                most_recent_timestamp = group_timestamp
-                most_recent_receipt = receipt_id
+            if summary is None:
+                self._set_empty()
+                return
 
-        if not most_recent_receipt:
-            self._attr_state = 0
-            self._attr_icon = "mdi:cart-off"
-            self._hass_custom_attributes = {}
-            self.async_write_ha_state()
+        if not summary.get("items"):
+            self._set_empty()
             return
 
-        order_transactions = grouped[most_recent_receipt]
-
-        # Build per-item details
-        items = []
-        order_total = 0
-        total_quantity = 0
-        for txn in order_transactions:
-            detail = build_transaction_detail(txn)
-            items.append(detail)
-            qty = detail.get("quantity") or 1
-            order_total += detail["price_amount"] * qty
-            total_quantity += qty
-
-        # Get order-level info from the first transaction
-        first_item = items[0]
-        order_date = min(
-            (item["created_date"] for item in items if item.get("created_date")),
-            default=None,
+        self._attr_state = sum(
+            (item.get("quantity") or 1) for item in summary["items"]
         )
-
-        self._attr_state = total_quantity
         self._attr_icon = "mdi:cart"
-
-        self._hass_custom_attributes = {
-            "receipt_id": most_recent_receipt,
-            "buyer_user_id": first_item.get("buyer_user_id"),
-            "order_total": round(order_total, 2),
-            "currency_code": first_item.get("price_currency", "USD"),
-            "order_date": order_date,
-            "item_count": len(items),
-            "items": items,
-        }
-
+        self._hass_custom_attributes = summary
         self.async_write_ha_state()
+
+    def _set_empty(self) -> None:
+        self._attr_state = 0
+        self._attr_icon = "mdi:cart-off"
+        self._hass_custom_attributes = {}
+        self.async_write_ha_state()
+
+    @staticmethod
+    def _synthesize_from_transactions(transactions: list[dict]) -> dict | None:
+        """Build a minimal receipt-shaped summary from a transactions list."""
+        if not transactions:
+            return None
+        grouped: dict[str, list[dict]] = defaultdict(list)
+        for txn in transactions:
+            key = str(txn.get("receipt_id") or txn.get("transaction_id", ""))
+            grouped[key].append(txn)
+
+        if not grouped:
+            return None
+        most_recent_id = max(
+            grouped,
+            key=lambda k: max(
+                (t.get("created_timestamp", 0) for t in grouped[k]), default=0
+            ),
+        )
+        synthetic_receipt = {
+            "receipt_id": most_recent_id,
+            "buyer_user_id": grouped[most_recent_id][0].get("buyer_user_id"),
+            "transactions": grouped[most_recent_id],
+        }
+        return build_receipt_summary(synthetic_receipt)
 
 
 class EtsyShopStats(CoordinatorEntity, SensorEntity):

--- a/custom_components/etsyapp/utils.py
+++ b/custom_components/etsyapp/utils.py
@@ -1,6 +1,41 @@
 """Shared utility functions for the Etsy integration."""
 
 from datetime import datetime
+from typing import Any
+
+
+def format_money(money_obj: dict | None) -> dict | None:
+    """Convert an Etsy money object to a flat {amount, currency_code} dict.
+
+    Etsy returns money as {amount, divisor, currency_code}. The divisor is
+    usually 100 but isn't guaranteed by the API, so we honor it explicitly.
+    Returns None if the input is missing or unparseable so callers can omit
+    the attribute cleanly.
+    """
+    if not money_obj:
+        return None
+    amount = money_obj.get("amount")
+    divisor = money_obj.get("divisor") or 100
+    if amount is None:
+        return None
+    try:
+        value = float(amount) / float(divisor)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return None
+    return {
+        "amount": round(value, 2),
+        "currency_code": money_obj.get("currency_code", "USD"),
+    }
+
+
+def _format_timestamp(ts: Any) -> str | None:
+    """Format a Unix timestamp as YYYY-MM-DD HH:MM:SS, or return None."""
+    if not ts:
+        return None
+    try:
+        return datetime.fromtimestamp(int(ts)).strftime("%Y-%m-%d %H:%M:%S")
+    except (ValueError, TypeError, OSError):
+        return None
 
 
 def build_transaction_detail(transaction: dict) -> dict:
@@ -8,24 +43,6 @@ def build_transaction_detail(transaction: dict) -> dict:
     price = transaction.get("price", {})
     amount = float(price.get("amount", 0)) / 100 if price.get("amount") else 0
     currency = price.get("currency_code", "USD")
-
-    created_date = None
-    if transaction.get("created_timestamp"):
-        try:
-            created_date = datetime.fromtimestamp(
-                transaction["created_timestamp"]
-            ).strftime("%Y-%m-%d %H:%M:%S")
-        except (ValueError, TypeError):
-            created_date = transaction.get("created_timestamp")
-
-    updated_date = None
-    if transaction.get("updated_timestamp"):
-        try:
-            updated_date = datetime.fromtimestamp(
-                transaction["updated_timestamp"]
-            ).strftime("%Y-%m-%d %H:%M:%S")
-        except (ValueError, TypeError):
-            updated_date = transaction.get("updated_timestamp")
 
     variations = []
     for variation in transaction.get("variations", []):
@@ -44,6 +61,107 @@ def build_transaction_detail(transaction: dict) -> dict:
         "price_amount": amount,
         "price_currency": currency,
         "variations": variations,
-        "created_date": created_date,
-        "updated_date": updated_date,
+        "created_date": _format_timestamp(transaction.get("created_timestamp")),
+        "updated_date": _format_timestamp(transaction.get("updated_timestamp")),
     }
+
+
+def build_receipt_summary(receipt: dict, payment: dict | None = None) -> dict:
+    """Build the attribute dict for a single receipt, used by sensor entities.
+
+    Preserves the legacy EtsyLastOrder attribute keys (receipt_id,
+    buyer_user_id, order_total, currency_code, order_date, item_count, items)
+    so existing user templates/dashboards keep working. order_total stays
+    items-only (subtotal); use the explicit subtotal/grandtotal/amount_net
+    keys when a different figure is needed.
+
+    Optional fields (buyer_name, message_from_buyer, payment-derived amounts)
+    are omitted when null so attribute-row cards skip them cleanly.
+    """
+    transactions = receipt.get("transactions") or []
+    items = [build_transaction_detail(t) for t in transactions]
+
+    subtotal_money = format_money(receipt.get("subtotal"))
+    grandtotal_money = format_money(receipt.get("grandtotal"))
+    shipping_money = format_money(receipt.get("total_shipping_cost"))
+    tax_money = format_money(receipt.get("total_tax_cost"))
+    discount_money = format_money(receipt.get("discount_amt"))
+
+    # Items-only subtotal computed from transactions, kept as the canonical
+    # order_total for backward compatibility with existing templates.
+    items_subtotal = sum(
+        (item["price_amount"] or 0) * (item.get("quantity") or 1)
+        for item in items
+    )
+
+    currency = (
+        (grandtotal_money or subtotal_money or {}).get("currency_code")
+        or (items[0]["price_currency"] if items else "USD")
+    )
+
+    order_date = _format_timestamp(receipt.get("created_timestamp"))
+    if not order_date and items:
+        order_date = min(
+            (item["created_date"] for item in items if item.get("created_date")),
+            default=None,
+        )
+
+    summary: dict[str, Any] = {
+        "receipt_id": str(receipt.get("receipt_id", "")),
+        "buyer_user_id": str(receipt.get("buyer_user_id", "")),
+        "order_total": round(items_subtotal, 2),
+        "currency_code": currency,
+        "order_date": order_date,
+        "item_count": len(items),
+        "items": items,
+    }
+
+    # Receipt status fields (omitted on synthesized receipts from the
+    # legacy fallback path where receipts data isn't available)
+    if receipt.get("status") is not None:
+        summary["status"] = receipt["status"]
+    if receipt.get("is_paid") is not None:
+        summary["is_paid"] = receipt["is_paid"]
+    if receipt.get("is_shipped") is not None:
+        summary["is_shipped"] = receipt["is_shipped"]
+
+    # Optional buyer name (may be null for some sellers per Etsy 2024 policy)
+    buyer_name = receipt.get("name")
+    if buyer_name:
+        summary["buyer_name"] = buyer_name
+
+    message = receipt.get("message_from_buyer")
+    if message:
+        summary["message_from_buyer"] = message
+
+    if receipt.get("is_gift"):
+        summary["is_gift"] = True
+        gift_message = receipt.get("gift_message")
+        if gift_message:
+            summary["gift_message"] = gift_message
+
+    # Receipt-level totals (split out so templates can use them directly)
+    if subtotal_money:
+        summary["subtotal"] = subtotal_money["amount"]
+    if grandtotal_money:
+        summary["grandtotal"] = grandtotal_money["amount"]
+    if shipping_money:
+        summary["total_shipping_cost"] = shipping_money["amount"]
+    if tax_money:
+        summary["total_tax_cost"] = tax_money["amount"]
+    if discount_money and discount_money["amount"]:
+        summary["discount_amount"] = discount_money["amount"]
+
+    # Payment-derived figures (only present when payment was fetched)
+    if payment:
+        gross = format_money(payment.get("amount_gross"))
+        fees = format_money(payment.get("amount_fees"))
+        net = format_money(payment.get("amount_net"))
+        if gross:
+            summary["amount_gross"] = gross["amount"]
+        if fees:
+            summary["amount_fees"] = fees["amount"]
+        if net:
+            summary["amount_net"] = net["amount"]
+
+    return summary

--- a/tests/fixtures/etsy_receipts_data.json
+++ b/tests/fixtures/etsy_receipts_data.json
@@ -1,0 +1,119 @@
+{
+  "shop": {
+    "shop_id": 56636211,
+    "shop_name": "TestEtsyShop",
+    "title": "Handmade Crafts & Accessories",
+    "announcement": "Welcome to our shop! Check out our latest items.",
+    "currency_code": "USD",
+    "creation_timestamp": 1234567890,
+    "sale_message": "Thanks for your purchase!",
+    "digital_sale_message": "Download your files below.",
+    "review_average": 4.8,
+    "review_count": 125,
+    "transaction_sold_count": 1500,
+    "listing_active_count": 2,
+    "is_vacation": false,
+    "vacation_message": "",
+    "url": "https://www.etsy.com/shop/TestEtsyShop"
+  },
+  "listings": [
+    {
+      "listing_id": 123456789,
+      "title": "Handmade Leather Wallet",
+      "state": "active",
+      "price": {"amount": 2500, "divisor": 100, "currency_code": "USD"},
+      "quantity": 5,
+      "views": 250,
+      "num_favorers": 12,
+      "currency_code": "USD"
+    },
+    {
+      "listing_id": 987654321,
+      "title": "Custom Wood Sign",
+      "state": "active",
+      "price": {"amount": 4500, "divisor": 100, "currency_code": "USD"},
+      "quantity": 3,
+      "views": 180,
+      "num_favorers": 8,
+      "currency_code": "USD"
+    }
+  ],
+  "receipts": [
+    {
+      "receipt_id": 5550001,
+      "buyer_user_id": 22222222,
+      "name": "Jane Doe",
+      "status": "paid",
+      "is_paid": true,
+      "is_shipped": false,
+      "created_timestamp": 1693843200,
+      "updated_timestamp": 1693843200,
+      "message_from_buyer": "Please ship soon!",
+      "is_gift": false,
+      "subtotal": {"amount": 4900, "divisor": 100, "currency_code": "USD"},
+      "grandtotal": {"amount": 5500, "divisor": 100, "currency_code": "USD"},
+      "total_shipping_cost": {"amount": 500, "divisor": 100, "currency_code": "USD"},
+      "total_tax_cost": {"amount": 100, "divisor": 100, "currency_code": "USD"},
+      "discount_amt": {"amount": 0, "divisor": 100, "currency_code": "USD"},
+      "transactions": [
+        {
+          "transaction_id": 111111111,
+          "receipt_id": 5550001,
+          "title": "Handmade Leather Wallet",
+          "listing_id": 123456789,
+          "buyer_user_id": 22222222,
+          "quantity": 1,
+          "price": {"amount": 2500, "divisor": 100, "currency_code": "USD"},
+          "created_timestamp": 1693843200,
+          "updated_timestamp": 1693843200
+        },
+        {
+          "transaction_id": 222222222,
+          "receipt_id": 5550001,
+          "title": "Matching Leather Keychain",
+          "listing_id": 123456790,
+          "buyer_user_id": 22222222,
+          "quantity": 2,
+          "price": {"amount": 1200, "divisor": 100, "currency_code": "USD"},
+          "created_timestamp": 1693843200,
+          "updated_timestamp": 1693843200
+        }
+      ]
+    },
+    {
+      "receipt_id": 5550002,
+      "buyer_user_id": 44444444,
+      "name": "John Smith",
+      "status": "completed",
+      "is_paid": true,
+      "is_shipped": true,
+      "created_timestamp": 1693756800,
+      "updated_timestamp": 1693756800,
+      "is_gift": false,
+      "subtotal": {"amount": 4500, "divisor": 100, "currency_code": "USD"},
+      "grandtotal": {"amount": 5000, "divisor": 100, "currency_code": "USD"},
+      "total_shipping_cost": {"amount": 500, "divisor": 100, "currency_code": "USD"},
+      "total_tax_cost": {"amount": 0, "divisor": 100, "currency_code": "USD"},
+      "transactions": [
+        {
+          "transaction_id": 333333333,
+          "receipt_id": 5550002,
+          "title": "Custom Wood Sign",
+          "listing_id": 987654321,
+          "buyer_user_id": 44444444,
+          "quantity": 1,
+          "price": {"amount": 4500, "divisor": 100, "currency_code": "USD"},
+          "created_timestamp": 1693756800,
+          "updated_timestamp": 1693756800
+        }
+      ]
+    }
+  ],
+  "last_payment": {
+    "payment_id": 999999,
+    "receipt_id": 5550001,
+    "amount_gross": {"amount": 5500, "divisor": 100, "currency_code": "USD"},
+    "amount_fees": {"amount": 825, "divisor": 100, "currency_code": "USD"},
+    "amount_net": {"amount": 4675, "divisor": 100, "currency_code": "USD"}
+  }
+}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -23,9 +23,9 @@ async def test_async_setup(hass):
 async def test_etsy_update_coordinator(hass, aioclient_mock):
     """Test the EtsyUpdateCoordinator with mocked API responses."""
     fixtures_path = Path(__file__).parent / "fixtures"
-    with open(fixtures_path / "etsy_shop_data.json") as file:
-        etsy_data = json.load(file)
-    
+    with open(fixtures_path / "etsy_receipts_data.json") as file:
+        receipts_data = json.load(file)
+
     # Mock ConfigEntry
     mock_entry = Mock()
     mock_entry.data = {
@@ -34,62 +34,67 @@ async def test_etsy_update_coordinator(hass, aioclient_mock):
             "access_token": "test_access_token"
         },
         "auth_implementation_client_id": "test_client_id",
-        "auth_implementation": DOMAIN,  # Add auth implementation for OAuth
+        "auth_implementation": DOMAIN,
     }
 
-    # Mock the Etsy API endpoints
     shop_url = "https://openapi.etsy.com/v3/application/shops/56636211"
     listings_url = "https://openapi.etsy.com/v3/application/shops/56636211/listings/active"
-    transactions_url = "https://openapi.etsy.com/v3/application/shops/56636211/transactions"
-    
-    # Mock shop endpoint
+    receipts_url = "https://openapi.etsy.com/v3/application/shops/56636211/receipts"
+    payments_url = (
+        "https://openapi.etsy.com/v3/application/shops/56636211/receipts/5550001/payments"
+    )
+
     aioclient_mock.get(
         shop_url,
-        json={"results": [etsy_data["shop"]]},
+        json={"results": [receipts_data["shop"]]},
         status=200,
     )
-    
-    # Mock listings endpoint
     aioclient_mock.get(
         listings_url,
         json={
-            "results": etsy_data["listings"],
-            "count": etsy_data["listings_count"]
+            "results": receipts_data["listings"],
+            "count": len(receipts_data["listings"]),
         },
         status=200,
     )
-    
-    # Mock transactions endpoint
     aioclient_mock.get(
-        transactions_url,
+        receipts_url,
         json={
-            "results": etsy_data["transactions"],
-            "count": etsy_data["transactions_count"]
+            "results": receipts_data["receipts"],
+            "count": len(receipts_data["receipts"]),
         },
+        status=200,
+    )
+    aioclient_mock.get(
+        payments_url,
+        json={"results": [receipts_data["last_payment"]]},
         status=200,
     )
 
-    # Initialize the coordinator
     coordinator = EtsyUpdateCoordinator(hass, mock_entry)
-    
-    # Mock OAuth session for tests
-    from unittest.mock import AsyncMock
+
     coordinator._oauth_session_initialized = True
     mock_oauth_session = AsyncMock()
     mock_oauth_session.async_ensure_token_valid = AsyncMock()
     mock_oauth_session.token = {"access_token": "test_access_token"}
     coordinator.oauth_session = mock_oauth_session
 
-    # Perform the update
     await coordinator.async_refresh()
 
-    # Assert the data was fetched correctly
+    # Existing assertions preserved — transactions list still 3 line items,
+    # transactions_count still 3. Backward compatibility for EtsyRecentOrders
+    # and EtsyShopStats.
     assert coordinator.last_update_success
     assert coordinator.data['shop']['shop_name'] == "TestEtsyShop"
     assert coordinator.data['listings_count'] == 2
     assert coordinator.data['transactions_count'] == 3
     assert len(coordinator.data['listings']) == 2
     assert len(coordinator.data['transactions']) == 3
+
+    # New keys
+    assert len(coordinator.data['receipts']) == 2
+    assert coordinator.data['receipts'][0]['receipt_id'] == 5550001
+    assert coordinator.data['last_payment']['amount_net']['amount'] == 4675
 
 
 @pytest.mark.asyncio
@@ -191,11 +196,11 @@ async def test_token_refresh_returns_cached_data(hass, aioclient_mock):
     # First successful API call to populate cache
     shop_url = "https://openapi.etsy.com/v3/application/shops/56636211"
     listings_url = "https://openapi.etsy.com/v3/application/shops/56636211/listings/active"
-    transactions_url = "https://openapi.etsy.com/v3/application/shops/56636211/transactions"
-    
+    receipts_url = "https://openapi.etsy.com/v3/application/shops/56636211/receipts"
+
     aioclient_mock.get(shop_url, json={"results": [etsy_data["shop"]]}, status=200)
     aioclient_mock.get(listings_url, json={"results": etsy_data["listings"], "count": 2}, status=200)
-    aioclient_mock.get(transactions_url, json={"results": etsy_data["transactions"], "count": 2}, status=200)
+    aioclient_mock.get(receipts_url, json={"results": [], "count": 0}, status=200)
     
     # Mock the token refresh endpoint to fail
     aioclient_mock.post(
@@ -253,8 +258,8 @@ async def test_rate_limit_returns_cached_data(hass, aioclient_mock):
         json={"results": [], "count": 0}, status=200
     )
     aioclient_mock.get(
-        "https://openapi.etsy.com/v3/application/shops/56636211/transactions",
-        json={"results": [], "count": 0}, status=200  
+        "https://openapi.etsy.com/v3/application/shops/56636211/receipts",
+        json={"results": [], "count": 0}, status=200,
     )
     
     coordinator = EtsyUpdateCoordinator(hass, mock_entry)
@@ -328,3 +333,184 @@ async def test_consecutive_failures_tracking(hass):
         with patch.object(coordinator, '_check_for_changes', new_callable=AsyncMock):
             await coordinator.async_refresh()
     assert coordinator._consecutive_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_payment_fetch_failure_is_graceful(hass, aioclient_mock):
+    """If /payments returns non-200, coordinator still succeeds with
+    last_payment=None and the sensor omits payment-derived fields."""
+    fixtures_path = Path(__file__).parent / "fixtures"
+    with open(fixtures_path / "etsy_receipts_data.json") as file:
+        receipts_data = json.load(file)
+
+    mock_entry = Mock()
+    mock_entry.data = {
+        "shop_id": "56636211",
+        "token": {"access_token": "t"},
+        "auth_implementation_client_id": "test_client_id",
+        "auth_implementation": DOMAIN,
+    }
+
+    base = "https://openapi.etsy.com/v3/application/shops/56636211"
+    aioclient_mock.get(base, json={"results": [receipts_data["shop"]]}, status=200)
+    aioclient_mock.get(
+        f"{base}/listings/active",
+        json={"results": [], "count": 0}, status=200,
+    )
+    aioclient_mock.get(
+        f"{base}/receipts",
+        json={"results": receipts_data["receipts"], "count": 2},
+        status=200,
+    )
+    # /payments returns 404 — Etsy can do this for very-new receipts
+    aioclient_mock.get(
+        f"{base}/receipts/5550001/payments",
+        status=404,
+    )
+
+    coordinator = EtsyUpdateCoordinator(hass, mock_entry)
+    coordinator._oauth_session_initialized = True
+    mock_oauth = AsyncMock()
+    mock_oauth.async_ensure_token_valid = AsyncMock()
+    mock_oauth.token = {"access_token": "t"}
+    coordinator.oauth_session = mock_oauth
+
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert coordinator.data["last_payment"] is None
+    assert len(coordinator.data["receipts"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_proxy_404_falls_back_to_transactions(hass):
+    """When the proxy returns 404 on /receipts (older proxy version), the
+    coordinator falls back to /transactions and still returns a valid shape."""
+    from custom_components.etsyapp.const import (
+        CONNECTION_MODE_PROXY,
+        CONF_CONNECTION_MODE,
+        CONF_PROXY_URL,
+        CONF_PROXY_API_KEY,
+        CONF_HMAC_SECRET,
+    )
+
+    mock_entry = Mock()
+    mock_entry.data = {
+        CONF_CONNECTION_MODE: CONNECTION_MODE_PROXY,
+        CONF_PROXY_URL: "https://proxy.example",
+        CONF_PROXY_API_KEY: "k",
+        CONF_HMAC_SECRET: "s",
+        "shop_id": "56636211",
+    }
+
+    coordinator = EtsyUpdateCoordinator(hass, mock_entry)
+
+    legacy_txn = {
+        "transaction_id": 1,
+        "receipt_id": 99,
+        "title": "Legacy item",
+        "listing_id": 1,
+        "buyer_user_id": 42,
+        "quantity": 1,
+        "price": {"amount": 1000, "divisor": 100, "currency_code": "USD"},
+        "created_timestamp": 1693843200,
+        "updated_timestamp": 1693843200,
+    }
+
+    with patch.object(
+        coordinator, "_fetch_shop_info_proxy",
+        return_value={"shop_name": "TestShop"},
+    ), patch.object(
+        coordinator, "_fetch_listings_proxy",
+        return_value={"results": [], "count": 0},
+    ), patch.object(
+        coordinator, "_fetch_receipts_proxy",
+        return_value=None,  # Simulates 404 from older proxy
+    ), patch.object(
+        coordinator, "_fetch_transactions_proxy",
+        return_value={"results": [legacy_txn], "count": 1},
+    ) as mock_legacy:
+        data = await coordinator._fetch_via_proxy()
+
+    mock_legacy.assert_called_once()
+    assert data["receipts"] == []
+    assert data["last_payment"] is None
+    assert len(data["transactions"]) == 1
+    assert data["transactions_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_new_order_event_payload_shape(hass):
+    """Pin the etsyapp_new_order event payload shape — outer keys are public
+    API for users' automations and must not change."""
+    fixtures_path = Path(__file__).parent / "fixtures"
+    with open(fixtures_path / "etsy_receipts_data.json") as file:
+        receipts_data = json.load(file)
+
+    mock_entry = Mock()
+    mock_entry.data = {
+        "shop_id": "56636211",
+        "token": {"access_token": "t", "expires_at": time.time() + 3600},
+        "auth_implementation_client_id": "test_client_id",
+    }
+    mock_entry.entry_id = "test_entry"
+    mock_entry.options = {}
+
+    coordinator = EtsyUpdateCoordinator(hass, mock_entry)
+
+    # Seed prior state — pretend we'd previously seen one transaction so the
+    # new-order branch fires (it skips when prev count is 0).
+    coordinator._prev_transactions_count = 1
+    coordinator._prev_receipt_ids = set()
+
+    # Stub the device lookup — _check_for_changes returns early when no device
+    # is registered, but the event-firing logic is what we're testing.
+    fake_device = Mock()
+    fake_device.id = "test_device_id"
+
+    captured = []
+
+    def _capture(event):
+        captured.append(event)
+
+    hass.bus.async_listen(f"{DOMAIN}_new_order", _capture)
+
+    receipts = receipts_data["receipts"]
+    flattened = []
+    for r in receipts:
+        flattened.extend(r.get("transactions") or [])
+
+    data = {
+        "shop": receipts_data["shop"],
+        "listings": [],
+        "transactions": flattened,
+        "receipts": receipts,
+        "last_payment": receipts_data["last_payment"],
+        "transactions_count": len(flattened),
+        "listings_count": 0,
+        "last_updated": "x",
+    }
+
+    with patch(
+        "homeassistant.helpers.device_registry.async_get"
+    ) as mock_dr_get:
+        mock_dr_get.return_value.async_get_device.return_value = fake_device
+        await coordinator._check_for_changes(data)
+    await hass.async_block_till_done()
+
+    assert len(captured) == 1
+    payload = captured[0].data
+    # Outer keys — these are the backward-compat contract.
+    assert set(payload.keys()) == {
+        "device_id",
+        "shop_name",
+        "new_orders",
+        "orders",
+        "receipts",
+    }
+    assert payload["shop_name"] == "TestEtsyShop"
+    assert payload["new_orders"] == len(flattened) - 1
+    # Receipts payload now carries enriched receipt summaries
+    jane = next(r for r in payload["receipts"] if r.get("buyer_name") == "Jane Doe")
+    assert jane["grandtotal"] == 55.0
+    assert jane["receipt_id"] == "5550001"

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -23,6 +23,31 @@ with open(fixtures_path / "etsy_shop_data.json") as file:
 with open(fixtures_path / "etsy_empty_data.json") as file:
     empty_data = json.load(file)
 
+with open(fixtures_path / "etsy_receipts_data.json") as file:
+    receipts_fixture = json.load(file)
+
+
+def _receipts_coordinator_data():
+    """Build a coordinator data dict matching the post-swap shape.
+
+    Mirrors what coordinator._fetch_direct now produces: receipts + a
+    flattened transactions list + last_payment.
+    """
+    receipts = receipts_fixture["receipts"]
+    transactions = []
+    for r in receipts:
+        transactions.extend(r.get("transactions") or [])
+    return {
+        "shop": receipts_fixture["shop"],
+        "listings": receipts_fixture["listings"],
+        "transactions": transactions,
+        "receipts": receipts,
+        "last_payment": receipts_fixture["last_payment"],
+        "listings_count": len(receipts_fixture["listings"]),
+        "transactions_count": len(transactions),
+        "last_updated": "2025-01-01 00:00:00.000000",
+    }
+
 
 @pytest.mark.asyncio
 async def test_etsy_shop_info_sensor():
@@ -221,6 +246,77 @@ async def test_etsy_last_order_sensor():
     titles = [item["title"] for item in items]
     assert "Handmade Leather Wallet" in titles
     assert "Matching Leather Keychain" in titles
+
+
+@pytest.mark.asyncio
+async def test_etsy_last_order_sensor_with_receipts():
+    """EtsyLastOrder pulls buyer name + totals from receipts when present."""
+    mock_coordinator = AsyncMock(spec=EtsyUpdateCoordinator)
+    mock_coordinator.data = _receipts_coordinator_data()
+    mock_coordinator.config_entry = AsyncMock()
+    mock_coordinator.config_entry.entry_id = "test_entry_id"
+    mock_coordinator.config_entry.options = {}
+
+    sensor = EtsyLastOrder(mock_coordinator)
+    sensor.async_write_ha_state = Mock()
+    sensor._handle_coordinator_update()
+
+    attrs = sensor.extra_state_attributes
+
+    # Legacy keys preserved (backward compatibility for existing dashboards)
+    assert attrs["receipt_id"] == "5550001"
+    assert attrs["buyer_user_id"] == "22222222"
+    assert attrs["order_total"] == 49.0  # items-only subtotal — UNCHANGED meaning
+    assert attrs["currency_code"] == "USD"
+    assert attrs["item_count"] == 2
+    assert len(attrs["items"]) == 2
+
+    # New receipt-level fields
+    assert attrs["buyer_name"] == "Jane Doe"
+    assert attrs["subtotal"] == 49.0
+    assert attrs["grandtotal"] == 55.0
+    assert attrs["total_shipping_cost"] == 5.0
+    assert attrs["total_tax_cost"] == 1.0
+    assert attrs["message_from_buyer"] == "Please ship soon!"
+    assert attrs["status"] == "paid"
+    assert attrs["is_paid"] is True
+    assert attrs["is_shipped"] is False
+
+    # Payment-derived figures (the issue's primary ask)
+    assert attrs["amount_gross"] == 55.0
+    assert attrs["amount_fees"] == 8.25
+    assert attrs["amount_net"] == 46.75
+
+
+@pytest.mark.asyncio
+async def test_etsy_last_order_legacy_fallback():
+    """Legacy fallback path: no receipts key, just transactions (proxy skew)."""
+    mock_coordinator = AsyncMock(spec=EtsyUpdateCoordinator)
+    # etsy_data has transactions but no receipts/last_payment — mimics an
+    # older proxy that hasn't been upgraded yet.
+    mock_coordinator.data = etsy_data
+    mock_coordinator.config_entry = AsyncMock()
+    mock_coordinator.config_entry.entry_id = "test_entry_id"
+    mock_coordinator.config_entry.options = {}
+
+    sensor = EtsyLastOrder(mock_coordinator)
+    sensor.async_write_ha_state = Mock()
+    sensor._handle_coordinator_update()
+
+    attrs = sensor.extra_state_attributes
+
+    # Legacy attrs still work — synthesizes a receipt from grouped transactions
+    assert sensor.state == 3
+    assert attrs["receipt_id"] == "5550001"
+    assert attrs["buyer_user_id"] == "22222222"
+    assert attrs["order_total"] == 49.0
+    assert attrs["item_count"] == 2
+    assert attrs["currency_code"] == "USD"
+
+    # New receipt-level fields absent (no source data to populate them)
+    assert "buyer_name" not in attrs
+    assert "grandtotal" not in attrs
+    assert "amount_net" not in attrs
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #23. Replaces the `/transactions` fetch with `/receipts` in both direct and proxy modes so the Last Order sensor can surface buyer name, order totals, and net payout (`amount_net` — what hits the bank after Etsy fees, fetched via `/payments` for the most recent receipt only).

Receipts embed their transactions array, so `EtsyRecentOrders` and `EtsyShopStats` keep working unchanged via a client-side flatten.

## New `sensor.etsy_last_order` attributes

`buyer_name`, `grandtotal`, `subtotal`, `total_shipping_cost`, `total_tax_cost`, `discount_amount`, `message_from_buyer`, `is_gift`, `gift_message`, `status`, `is_paid`, `is_shipped`, `amount_gross`, `amount_fees`, `amount_net`.

Each new field is omitted when null so attribute-row cards render cleanly.

## Backward compatibility

- Legacy `EtsyLastOrder` attribute keys preserved. `order_total` stays as items-only subtotal — new templates can use `grandtotal` or `amount_net` for different figures.
- `etsyapp_new_order` event outer keys pinned via test (`device_id`, `shop_name`, `new_orders`, `orders`, `receipts`). Receipts in the payload now carry the enriched fields.
- Proxy mode falls back to `/transactions` on 404 for older proxy versions (requires proxy v1.1.0 for the full experience; see companion PR).
- Direct mode talks to Etsy directly — no version dependency.

## Notable correctness notes

- Etsy's `/receipts` endpoint does **not** support `sort_on` / `sort_order` query params (verified against [Etsy's OpenAPI spec via etsy-ts](https://github.com/Granga/etsy-ts/blob/master/src/api/data-contracts.ts)). Receipts are sorted client-side by `created_timestamp` desc to guarantee `receipts[0]` is the most recent.
- `/payments` returns the `IPayments` list type even for a single-payment-per-receipt call; unwrapping handles both shapes.

## Test plan

- [x] All 36 unit tests pass (`pytest tests/`)
- [x] Backward-compat invariants pinned:
  - `EtsyLastOrder.order_total` equals items-only subtotal, not grandtotal
  - `EtsyRecentOrders` / `EtsyShopStats` produce identical values via the flattened transactions
  - `etsyapp_new_order` event outer keys unchanged
- [x] New paths covered:
  - Direct mode: receipts + payments fetch end-to-end
  - Payment fetch returning 404 leaves `last_payment=None` gracefully
  - Proxy 404 on `/receipts` falls back to `/transactions`
  - Sensor with full receipts data populates all new attrs
  - Sensor with legacy-only transactions data falls back to client-side grouping
- [ ] Manual smoke test against a real Etsy shop (recommended before release)