### PR TITLE
fix: send shared secret in x-api-key header for direct API

### DIFF
--- a/custom_components/etsyapp/config_flow.py
+++ b/custom_components/etsyapp/config_flow.py
@@ -13,7 +13,7 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 
 from .const import (
-    DOMAIN, 
+    DOMAIN,
     ETSY_API_BASE,
     CONNECTION_MODE_DIRECT,
     CONNECTION_MODE_PROXY,
@@ -64,7 +64,7 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
     DOMAIN = DOMAIN
     VERSION = 1
     MINOR_VERSION = 1
-    
+
     @staticmethod
     @config_entries.callback
     def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
@@ -90,7 +90,7 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
     ) -> FlowResult:
         """Handle a flow initialized by the user."""
         return await self.async_step_connection_mode(user_input)
-    
+
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -158,37 +158,37 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                     "shop_name": entry.data.get("shop_name", "your shop"),
                 }
             )
-    
+
     async def async_step_reauth(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle re-authentication for missing credentials."""
         self.reauth_entry = self.hass.config_entries.async_get_entry(
             self.context.get("entry_id")
         )
-        
+
         # Check if user_input has the required fields (not just if it exists)
         if user_input is not None and CONF_CLIENT_SECRET in user_input:
             # Store the new credentials
             new_data = dict(self.reauth_entry.data)
             new_data["client_secret"] = user_input[CONF_CLIENT_SECRET]
-            
+
             # Also update the auth_implementation_client_id if provided
             if CONF_CLIENT_ID in user_input:
                 new_data["auth_implementation_client_id"] = user_input[CONF_CLIENT_ID]
-            
+
             # Update the config entry
             self.hass.config_entries.async_update_entry(
                 self.reauth_entry,
                 data=new_data
             )
-            
+
             # Reload the integration
             await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
-            
+
             return self.async_abort(reason="reauth_successful")
-        
+
         # Pre-fill client_id if available
         client_id = self.reauth_entry.data.get("auth_implementation_client_id", "")
-        
+
         return self.async_show_form(
             step_id="reauth",
             data_schema=vol.Schema({
@@ -199,7 +199,7 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                 "instructions": "Your Etsy credentials are missing or incomplete. Please re-enter them from your Etsy Developer Dashboard."
             }
         )
-    
+
     async def async_step_connection_mode(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -212,7 +212,7 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                 return await self.async_step_proxy_config()
             else:
                 return await self.async_step_direct_credentials()
-        
+
         return self.async_show_form(
             step_id="connection_mode",
             data_schema=vol.Schema({
@@ -226,7 +226,7 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                 "proxy_desc": "Use the proxy service to connect without an Etsy developer account (Beta)"
             }
         )
-    
+
     async def async_step_direct_credentials(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -237,10 +237,10 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                 CONF_CLIENT_ID: user_input[CONF_CLIENT_ID],
                 CONF_CLIENT_SECRET: user_input[CONF_CLIENT_SECRET],
             }
-            
+
             # Create and register the OAuth2 implementation
             from homeassistant.helpers import config_entry_oauth2_flow
-            
+
             # Create implementation with user's credentials (using our PKCE-enabled implementation)
             implementation = EtsyOAuth2Implementation(
                 self.hass,
@@ -248,20 +248,20 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                 user_input[CONF_CLIENT_ID],
                 user_input[CONF_CLIENT_SECRET],
             )
-            
+
             # Register it as an available implementation
             config_entry_oauth2_flow.async_register_implementation(
                 self.hass,
                 DOMAIN,
                 implementation
             )
-            
+
             # Set this as the active implementation for this flow
             self.flow_impl = implementation
-            
+
             # Continue with OAuth flow
             return await self.async_step_pick_implementation(user_input={"implementation": DOMAIN})
-        
+
         return self.async_show_form(
             step_id="direct_credentials",
             data_schema=vol.Schema({
@@ -272,13 +272,13 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                 "instructions": "Enter your Etsy API credentials from the Etsy Developer Dashboard"
             }
         )
-    
+
     async def async_step_proxy_config(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle proxy configuration."""
         errors = {}
-        
+
         if user_input is not None:
             # Validate proxy connection with HMAC if provided
             valid = await self._validate_proxy_connection(
@@ -286,13 +286,13 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                 user_input[CONF_PROXY_API_KEY],
                 user_input.get(CONF_HMAC_SECRET)
             )
-            
+
             if valid:
                 # Clean up the URL before storing
                 proxy_url = user_input[CONF_PROXY_URL].rstrip('/')
                 if proxy_url.endswith('/api/v1'):
                     proxy_url = proxy_url[:-7]  # Remove '/api/v1'
-                    
+
                 # Store proxy config and proceed to shop selection
                 self.proxy_config = {
                     CONF_CONNECTION_MODE: CONNECTION_MODE_PROXY,
@@ -303,7 +303,7 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                 return await self.async_step_proxy_shop_selection()
             else:
                 errors["base"] = "invalid_proxy"
-        
+
         return self.async_show_form(
             step_id="proxy_config",
             data_schema=vol.Schema({
@@ -316,21 +316,21 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                 "instructions": "Enter your proxy service URL, API key, and HMAC secret for secure communication"
             }
         )
-    
+
     async def _validate_proxy_connection(
         self, proxy_url: str, api_key: str, hmac_secret: str | None = None
     ) -> bool:
         """Validate proxy connection with HMAC authentication if secret provided."""
         try:
             session = async_get_clientsession(self.hass)
-            
+
             # Clean up the URL - remove trailing slash and /api/v1 if present
             proxy_url = proxy_url.rstrip('/')
             if proxy_url.endswith('/api/v1'):
                 proxy_url = proxy_url[:-7]  # Remove '/api/v1'
-            
+
             path = "/health"
-            
+
             if hmac_secret:
                 # Use HMAC authentication
                 from .hmac_client import HMACClient
@@ -343,14 +343,14 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
             else:
                 # Fallback to simple bearer token (will fail on secure proxy)
                 headers = {"Authorization": f"Bearer {api_key}"}
-            
+
             # Test the health endpoint
             response = await session.get(
                 f"{proxy_url}{path}",
                 headers=headers,
                 timeout=10
             )
-            
+
             return response.status == 200
         except Exception as e:
             _LOGGER.error(f"Proxy validation failed: {e}")
@@ -362,7 +362,7 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
         """Handle shop selection step."""
         if user_input is not None:
             self._shop_id = user_input["shop_id"]
-            
+
             # Validate shop access
             if await self._validate_shop_access(self._shop_id):
                 return await self._create_config_entry()
@@ -377,10 +377,10 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
 
         # Get available shops from API
         shops = await self._get_user_shops()
-        
+
         if not shops:
             return self.async_abort(reason="no_shops_found")
-        
+
         if len(shops) == 1:
             # Only one shop, use it automatically
             self._shop_id = str(shops[0]["shop_id"])
@@ -389,7 +389,7 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
 
         # Multiple shops, let user choose
         shop_options = {str(shop["shop_id"]): shop["shop_name"] for shop in shops}
-        
+
         return self.async_show_form(
             step_id="shop_selection",
             data_schema=vol.Schema({
@@ -406,11 +406,11 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
         """Handle shop selection for proxy mode."""
         if user_input is not None:
             shop_id = user_input["shop_id"]
-            
+
             # Get shop name from our stored shop options
             shops = await self._get_proxy_shops()
             shop_name = next((shop.get("shop_name", shop.get("title", f"Shop {shop_id}")) for shop in shops if str(shop["shop_id"]) == shop_id), f"Shop {shop_id}")
-            
+
             # Create entry with proxy config and selected shop
             return self.async_create_entry(
                 title=f"{shop_name} ({shop_id}) - Proxy",
@@ -420,13 +420,13 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                     "shop_name": shop_name,
                 }
             )
-        
+
         # Get available shops from proxy
         shops = await self._get_proxy_shops()
-        
+
         if not shops:
             return self.async_abort(reason="no_shops_found")
-        
+
         if len(shops) == 1:
             # Only one shop, use it automatically
             shop_name = shops[0].get("shop_name", shops[0].get("title", f"Shop {shops[0]['shop_id']}"))
@@ -439,10 +439,10 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                     "shop_name": shop_name,
                 }
             )
-        
+
         # Multiple shops, let user choose
         shop_options = {str(shop["shop_id"]): shop.get("shop_name", shop.get("title", f"Shop {shop['shop_id']}")) for shop in shops}
-        
+
         return self.async_show_form(
             step_id="proxy_shop_selection",
             data_schema=vol.Schema({
@@ -452,15 +452,15 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                 "num_shops": str(len(shops)),
             },
         )
-    
+
     async def _get_proxy_shops(self) -> list[dict[str, Any]]:
         """Get shops from proxy service."""
         try:
             session = async_get_clientsession(self.hass)
-            
+
             path = "/api/v1/shops"
             hmac_secret = self.proxy_config.get(CONF_HMAC_SECRET)
-            
+
             if hmac_secret:
                 # Use HMAC authentication
                 from .hmac_client import HMACClient
@@ -473,19 +473,19 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
             else:
                 # This will fail on secure proxy
                 headers = {"Authorization": f"Bearer {self.proxy_config[CONF_PROXY_API_KEY]}"}
-            
+
             response = await session.get(
                 f"{self.proxy_config[CONF_PROXY_URL]}{path}",
                 headers=headers,
                 timeout=10
             )
-            
+
             if response.status == 200:
                 return await response.json()
             else:
                 _LOGGER.error(f"Failed to get shops from proxy: {response.status}")
                 return []
-                
+
         except Exception as e:
             _LOGGER.error(f"Error getting shops from proxy: {e}")
             return []
@@ -500,24 +500,27 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
         """Get list of shops for the authenticated user."""
         try:
             session = async_get_clientsession(self.hass)
-            
+
             # Extract user_id from access token (format: user_id.scope.token)
             access_token = self.oauth_data.get("token", {}).get("access_token", "")
             _LOGGER.debug("Extracting user_id from OAuth token")
-            
+
             if '.' in access_token:
                 user_id = access_token.split('.')[0]
                 _LOGGER.debug("Extracted user_id %s from access token", user_id)
             else:
                 _LOGGER.error(f"Unable to extract user_id from access token. Token format: {access_token[:20]}...")
                 return []
-            
+
             # Get client_id from various sources
             client_id = None
+            client_secret = None
             if hasattr(self, 'flow_impl') and self.flow_impl:
                 client_id = self.flow_impl.client_id
+                client_secret = self.flow_impl.client_secret
             elif self.etsy_credentials:
                 client_id = self.etsy_credentials.get(CONF_CLIENT_ID)
+                client_secret = self.etsy_credentials.get(CONF_CLIENT_SECRET)
             else:
                 # Try to get from registered implementations
                 from homeassistant.helpers import config_entry_oauth2_flow
@@ -528,37 +531,42 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                     # Get the first implementation
                     impl = next(iter(implementations.values()))
                     client_id = impl.client_id
-            
+                    client_secret = impl.client_secret
+
             if not client_id:
                 _LOGGER.error("Unable to get client_id for API request")
                 return []
-                
+
+            if not client_secret:
+                _LOGGER.error("Unable to get client_secret for API request")
+                return []
+
             headers = {
                 "Accept": "application/json",
                 "Content-Type": "application/json",
-                "x-api-key": client_id,
+                "x-api-key": f"{client_id}:{client_secret}",
                 "Authorization": f"Bearer {access_token}",
             }
-            
+
             # Get user's shops directly using extracted user_id
             shops_url = f"{ETSY_API_BASE}/users/{user_id}/shops"
             _LOGGER.debug("Fetching shops from Etsy API")
-            
+
             shops_response = await session.get(shops_url, headers=headers)
-            
+
             if shops_response.status != 200:
                 error_text = await shops_response.text()
                 _LOGGER.error(f"Failed to fetch shops. Status: {shops_response.status}, Error: {error_text}")
                 return []
-                
+
             shops_data = await shops_response.json()
             _LOGGER.debug("Processing shops response from Etsy API")
-            
+
             # The API can return data in different formats:
             # 1. Single shop: {"shop_id": 123, "shop_name": "...", ...}
             # 2. Multiple shops: {"count": 2, "results": [{shop1}, {shop2}]}
             # 3. Empty/No shops: {"count": 0, "results": []}
-            
+
             if isinstance(shops_data, dict):
                 if "results" in shops_data:
                     # Standard v3 format with results array
@@ -575,9 +583,9 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
                 # In case API returns a direct array of shops
                 _LOGGER.debug("API returned direct array of %s shop(s)", len(shops_data))
                 return shops_data
-            
+
             return []
-            
+
         except Exception as e:
             _LOGGER.error("Error fetching user shops: %s", e)
             return []
@@ -589,21 +597,21 @@ class EtsyFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain
             headers = {
                 "Accept": "application/json",
                 "Content-Type": "application/json",
-                "x-api-key": self.flow_impl.client_id,
+                "x-api-key": f"{self.flow_impl.client_id}:{self.flow_impl.client_secret}",
                 "Authorization": f"Bearer {self.access_token}",
             }
-            
+
             response = await session.get(
                 f"{ETSY_API_BASE}/shops/{shop_id}", headers=headers
             )
-            
+
             if response.status == 200:
                 shop_data = await response.json()
                 if shop_data.get("results"):
                     self._shop_name = shop_data["results"][0]["shop_name"]
                     return True
             return False
-            
+
         except Exception as e:
             _LOGGER.error("Error validating shop access: %s", e)
             return False
@@ -660,7 +668,7 @@ class EtsyOptionsFlow(config_entries.OptionsFlow):
                     default=current_options.get("listings_display_limit", 5),
                 ): vol.All(vol.Coerce(int), vol.Range(min=1, max=25)),
                 vol.Optional(
-                    "transactions_display_limit", 
+                    "transactions_display_limit",
                     default=current_options.get("transactions_display_limit", 10),
                 ): vol.All(vol.Coerce(int), vol.Range(min=1, max=25)),
                 vol.Optional(

--- a/custom_components/etsyapp/coordinator.py
+++ b/custom_components/etsyapp/coordinator.py
@@ -17,8 +17,8 @@ from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
-    DOMAIN, 
-    ETSY_API_BASE, 
+    DOMAIN,
+    ETSY_API_BASE,
     UPDATE_INTERVAL_SECONDS,
     API_FETCH_LIMIT,
     CONNECTION_MODE_DIRECT,
@@ -55,10 +55,10 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
         # Cache last successful data to prevent unavailability during token refresh
         self._last_successful_data = None
         self._consecutive_failures = 0
-        
+
         # Determine connection mode
         self.connection_mode = entry.data.get(CONF_CONNECTION_MODE, CONNECTION_MODE_DIRECT)
-        
+
         if self.connection_mode == CONNECTION_MODE_PROXY:
             # Proxy mode configuration
             self.proxy_url = entry.data.get(CONF_PROXY_URL)
@@ -85,14 +85,14 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=UPDATE_INTERVAL_SECONDS),
             always_update=False,  # Changed to False per HA best practices for performance
         )
-        
+
         _LOGGER.info(
             "Initialized Etsy coordinator for shop %s with %s mode, update interval: %s seconds",
             self.shop_id,
             self.connection_mode,
             UPDATE_INTERVAL_SECONDS
         )
-    
+
     async def _get_oauth_implementation(self):
         """Get OAuth implementation for this integration."""
         try:
@@ -111,7 +111,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                 data = await self._fetch_with_retry(self._fetch_via_proxy)
             else:
                 data = await self._fetch_with_retry(self._fetch_direct)
-            
+
             # Check for changes and fire events
             if data:
                 await self._check_for_changes(data)
@@ -121,7 +121,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                 self._last_successful_data = data
                 self._consecutive_failures = 0
                 _LOGGER.debug("Successfully fetched data for shop %s", self.shop_id)
-            
+
             return data
         except ConfigEntryAuthFailed:
             # Authentication failures need to trigger reauth flow
@@ -130,17 +130,17 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
         except Exception as err:
             self._consecutive_failures += 1
             error_str = str(err).lower()
-            
+
             # Check if this is a temporary failure that shouldn't cause unavailability
             is_temporary = (
-                "rate limit" in error_str or 
+                "rate limit" in error_str or
                 "429" in error_str or
                 "token" in error_str or
                 "refresh" in error_str or
                 "timeout" in error_str or
                 "connection" in error_str
             )
-            
+
             if is_temporary and self._last_successful_data:
                 # Return cached data for temporary failures to prevent unavailability
                 _LOGGER.warning(
@@ -149,22 +149,22 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                     err
                 )
                 return self._last_successful_data
-            
+
             # For persistent failures or no cached data, raise the error
             _LOGGER.error("Failed to update data: %s", err)
             raise UpdateFailed(f"Failed to update data: {err}") from err
-    
+
     async def _fetch_with_retry(self, fetch_func):
         """Fetch data with exponential backoff retry logic."""
         last_error = None
-        
+
         for attempt in range(self._max_retries):
             try:
                 return await fetch_func()
             except Exception as err:
                 last_error = err
                 error_str = str(err).lower()
-                
+
                 # Check if it's a rate limit error
                 if "429" in error_str or "rate limit" in error_str or "too many requests" in error_str:
                     self._retry_count = attempt + 1
@@ -174,7 +174,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                         # Add jitter to prevent thundering herd
                         jitter = random.uniform(0, delay * 0.1)
                         actual_delay = delay + jitter
-                        
+
                         _LOGGER.info(
                             "Rate limit hit, retrying in %.2f seconds (attempt %s/%s)",
                             actual_delay,
@@ -186,21 +186,21 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                     else:
                         _LOGGER.error("Max retries reached for rate limit")
                         raise UpdateFailed(f"Rate limit exceeded after {self._max_retries} retries") from err
-                
+
                 # For non-rate-limit errors, fail immediately
                 raise err
-        
+
         # If we've exhausted all retries
         raise UpdateFailed(f"Failed after {self._max_retries} attempts: {last_error}") from last_error
-    
+
     async def _fetch_via_proxy(self) -> dict[str, Any]:
         """Fetch data via proxy service."""
         if not self.proxy_url or not self.proxy_api_key:
             raise UpdateFailed("Missing proxy configuration")
-        
+
         if not self.hmac_client:
             raise UpdateFailed("HMAC secret not configured for secure proxy communication")
-        
+
         try:
             # First, get the user's shop if we don't have it
             if not self.shop_id:
@@ -211,7 +211,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                     path=path,
                     api_key=self.proxy_api_key
                 )
-                
+
                 response = await self.session.get(
                     f"{self.proxy_url}{path}",
                     headers=headers,
@@ -219,13 +219,13 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                 if response.status != 200:
                     text = await response.text()
                     raise UpdateFailed(f"Failed to get shops from proxy: {text}")
-                
+
                 shops_data = await response.json()
                 if shops_data and len(shops_data) > 0:
                     self.shop_id = str(shops_data[0]["shop_id"])
                 else:
                     raise UpdateFailed("No shops found via proxy")
-            
+
             # Now fetch shop data with HMAC signatures
             shop_info = await self._fetch_shop_info_proxy()
             listings_data = await self._fetch_listings_proxy()
@@ -260,15 +260,15 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                 "transactions_count": transactions_count,
                 "last_updated": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
             }
-            
+
             # Cache successful data for use during temporary failures
             self._last_successful_data = proxy_data
-            
+
             return proxy_data
         except Exception as e:
             _LOGGER.error("Error fetching data via proxy: %s", e)
             raise UpdateFailed(f"Failed to fetch data via proxy: {e}")
-    
+
     async def _fetch_shop_info_proxy(self) -> dict:
         """Fetch shop info via proxy."""
         path = f"/api/v1/shops/{self.shop_id}"
@@ -277,7 +277,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
             path=path,
             api_key=self.proxy_api_key
         )
-        
+
         response = await self.session.get(
             f"{self.proxy_url}{path}",
             headers=headers,
@@ -289,7 +289,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
             text = await response.text()
             raise UpdateFailed(f"Failed to get shop info: {text}")
         return await response.json()
-    
+
     async def _fetch_listings_proxy(self) -> dict:
         """Fetch listings via proxy."""
         # Limit listings for performance
@@ -300,7 +300,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
             path=path,
             api_key=self.proxy_api_key
         )
-        
+
         response = await self.session.get(
             f"{self.proxy_url}{path}",
             headers=headers,
@@ -311,7 +311,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.warning("Failed to get listings: %s", text)
             return {"results": [], "count": 0}
         return await response.json()
-    
+
     async def _fetch_transactions_proxy(self) -> dict:
         """Fetch transactions via proxy (legacy fallback for older proxies)."""
         path = f"/api/v1/shops/{self.shop_id}/transactions"
@@ -400,12 +400,12 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
         except Exception as err:
             _LOGGER.debug("Proxy payment fetch failed for receipt %s: %s", receipt_id, err)
             return None
-    
+
     async def _fetch_direct(self) -> dict[str, Any]:
         """Fetch data directly from Etsy API with automatic token refresh."""
         if not self.shop_id:
             raise UpdateFailed("Missing shop_id")
-        
+
         # Always try to initialize OAuth session for token refresh capability
         if not self._oauth_session_initialized:
             try:
@@ -423,16 +423,20 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.warning("Failed to initialize OAuth session: %s", err)
                 self.oauth_session = None
                 self._oauth_session_initialized = True
-            
-        # Get client_id from entry for API key header
+
+        # Get client credentials from entry for API key header
         client_id = self.config_entry.data.get("auth_implementation_client_id")
         if not client_id:
             raise UpdateFailed("Missing client_id for API authentication")
-        
+
+        client_secret = self.config_entry.data.get("client_secret")
+        if not client_secret:
+            raise UpdateFailed("Missing client_id for API authentication")
+
         # Get access token with refresh handling
         token = None
         token_refreshed = False
-        
+
         if self.oauth_session:
             # Use OAuth session for automatic token refresh
             try:
@@ -456,7 +460,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
             token_data = self.config_entry.data.get("token", {})
             token = token_data.get("access_token")
             expires_at = token_data.get("expires_at", 0)
-            
+
             # Check if token is expired (with 60 second buffer)
             if expires_at and time.time() > (expires_at - 60):
                 _LOGGER.info(
@@ -477,39 +481,39 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                     # Only trigger reauth if we have no cached data
                     self.config_entry.async_start_reauth(self._hass)
                     raise ConfigEntryAuthFailed("Token expired and refresh failed. Please re-authenticate.")
-            
+
             if not token:
                 raise UpdateFailed("No access token available")
-            
+
             _LOGGER.debug("Using token from config entry")
-            
+
         try:
-            
+
             headers = {
                 "Accept": "application/json",
-                "Content-Type": "application/json", 
-                "x-api-key": client_id,
+                "Content-Type": "application/json",
+                "x-api-key": f"{client_id}:{client_secret}",
                 "Authorization": f"Bearer {token}",
             }
-            
+
             # Get shop information
             shop_url = f"{ETSY_API_BASE}/shops/{self.shop_id}"
             shop_response = await self.session.get(shop_url, headers=headers)
-            
+
             # Check for authentication errors
             if shop_response.status == 401:
                 _LOGGER.error("Authentication failed - token may be expired")
                 raise ConfigEntryAuthFailed("Authentication failed. Please re-authenticate.")
-            
+
             # Check for rate limiting
             if shop_response.status == 429:
                 retry_after = shop_response.headers.get("Retry-After", "60")
                 _LOGGER.warning("Etsy API rate limit hit. Retry after %s seconds", retry_after)
                 raise UpdateFailed(f"Rate limit exceeded (429). Retry after {retry_after} seconds")
-            
+
             shop_response.raise_for_status()
             shop_data_raw = await shop_response.json()
-            
+
             # Shop endpoint returns either direct object or wrapped in results
             if isinstance(shop_data_raw, dict):
                 if "results" in shop_data_raw and isinstance(shop_data_raw["results"], list):
@@ -519,23 +523,23 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                     shop_data = shop_data_raw
             else:
                 shop_data = {}
-            
+
             # Get active listings (limited for performance)
             listings_url = f"{ETSY_API_BASE}/shops/{self.shop_id}/listings/active"
             listings_params = {"limit": API_FETCH_LIMIT}
             listings_response = await self.session.get(
                 listings_url, headers=headers, params=listings_params
             )
-            
+
             # Check for rate limiting
             if listings_response.status == 429:
                 retry_after = listings_response.headers.get("Retry-After", "60")
                 _LOGGER.warning("Etsy API rate limit hit on listings. Retry after %s seconds", retry_after)
                 raise UpdateFailed(f"Rate limit exceeded (429). Retry after {retry_after} seconds")
-            
+
             listings_response.raise_for_status()
             listings_data = await listings_response.json()
-            
+
             # Get recent receipts (replaces /transactions — receipts embed their
             # transactions array and additionally carry buyer name + order totals).
             # Etsy's /receipts endpoint doesn't accept sort_on/sort_order params
@@ -585,12 +589,12 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                 "transactions_count": len(flattened_transactions),
                 "last_updated": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
             }
-            
+
             # Cache successful data for use during token refresh
             self._last_successful_data = combined_data
-            
+
             return combined_data
-            
+
         except ConfigEntryAuthFailed:
             # Re-raise authentication failures without wrapping
             raise
@@ -640,20 +644,20 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
         try:
             token_data = self.config_entry.data.get("token", {})
             refresh_token = token_data.get("refresh_token")
-            
+
             if not refresh_token:
                 _LOGGER.error("No refresh token available for manual refresh")
                 return None
-            
+
             client_id = self.config_entry.data.get("auth_implementation_client_id")
             client_secret = self.config_entry.data.get("client_secret")
-            
+
             if not client_id or not client_secret:
                 _LOGGER.error("Missing client credentials for token refresh")
                 # Trigger re-authentication flow when credentials are missing
                 self.config_entry.async_start_reauth(self._hass)
                 return None
-            
+
             # Prepare token refresh request
             refresh_url = "https://api.etsy.com/v3/public/oauth/token"
             refresh_data = {
@@ -662,15 +666,15 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                 "client_secret": client_secret,
                 "refresh_token": refresh_token,
             }
-            
+
             async with self.session.post(refresh_url, data=refresh_data) as response:
                 if response.status != 200:
                     error_text = await response.text()
                     _LOGGER.error("Token refresh failed: %s", error_text)
                     return None
-                
+
                 new_token_data = await response.json()
-                
+
                 # Update the config entry with new token
                 new_data = dict(self.config_entry.data)
                 new_data["token"] = {
@@ -680,39 +684,39 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                     "expires_at": time.time() + new_token_data.get("expires_in", 3600),
                     "token_type": "Bearer",
                 }
-                
+
                 # Update the config entry
                 self._hass.config_entries.async_update_entry(
                     self.config_entry,
                     data=new_data
                 )
-                
+
                 _LOGGER.info(
                     "Successfully refreshed OAuth token (expires: %s)",
                     datetime.fromtimestamp(time.time() + new_token_data.get("expires_in", 3600)).strftime("%H:%M:%S")
                 )
                 return new_token_data["access_token"]
-                
+
         except Exception as err:
             _LOGGER.error("Manual token refresh failed: %s", err)
             return None
-    
+
     async def _check_for_changes(self, data: dict[str, Any]) -> None:
         """Check for changes in data and fire device trigger events."""
         # Get device ID for this integration
         from homeassistant.helpers import device_registry as dr
-        
+
         device_registry = dr.async_get(self._hass)
         device = device_registry.async_get_device(
             identifiers={(DOMAIN, self.config_entry.entry_id)}
         )
-        
+
         if not device:
             return
-        
+
         device_id = device.id
         shop = data.get("shop", {})
-        
+
         # Check for new orders. `new_orders` count is preserved as a delta of
         # transaction line items (legacy behavior — automations may template
         # off it). The richer `receipts` payload is built from real receipt
@@ -773,7 +777,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
             )
         self._prev_transactions_count = current_transactions_count
         self._prev_receipt_ids = current_receipt_ids
-        
+
         # Check for new reviews
         current_review_count = shop.get("review_count", 0)
         if current_review_count > self._prev_review_count and self._prev_review_count > 0:
@@ -788,7 +792,7 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                 }
             )
         self._prev_review_count = current_review_count
-        
+
         # Check for low stock
         listings = data.get("listings", [])
         for listing in listings:

--- a/custom_components/etsyapp/coordinator.py
+++ b/custom_components/etsyapp/coordinator.py
@@ -424,14 +424,18 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                 self.oauth_session = None
                 self._oauth_session_initialized = True
 
-        # Get client credentials from entry for API key header
+        # Get client credentials from entry needed for HTTP header
         client_id = self.config_entry.data.get("auth_implementation_client_id")
+        client_secret = self.config_entry.data.get("client_secret")
+
         if not client_id:
             raise UpdateFailed("Missing client_id for API authentication")
 
-        client_secret = self.config_entry.data.get("client_secret")
+        # Trigger re-authorization if client secret is missing
         if not client_secret:
-            raise UpdateFailed("Missing client_id for API authentication")
+            _LOGGER.error("Missing client_secret for API authentication")
+            self.config_entry.async_start_reauth(self._hass)
+            raise ConfigEntryAuthFailed("Missing client secret. Please re-authenticate.")
 
         # Get access token with refresh handling
         token = None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -35,6 +35,7 @@ async def test_etsy_update_coordinator(hass, aioclient_mock):
         },
         "auth_implementation_client_id": "test_client_id",
         "auth_implementation": DOMAIN,
+        "client_secret": "test_secret",
     }
 
     shop_url = "https://openapi.etsy.com/v3/application/shops/56636211"
@@ -103,7 +104,7 @@ async def test_etsy_coordinator_missing_credentials(hass):
     # Mock ConfigEntry without required data
     from homeassistant.config_entries import ConfigEntry
     from custom_components.etsyapp.const import DOMAIN
-    
+
     mock_entry = ConfigEntry(
         domain=DOMAIN,
         title="Test Etsy Shop",
@@ -130,18 +131,18 @@ async def test_etsy_coordinator_missing_credentials(hass):
         pass
 
 
-@pytest.mark.asyncio 
+@pytest.mark.asyncio
 async def test_etsy_coordinator_api_error(hass, aioclient_mock):
     """Test coordinator behavior when API returns error."""
     # Mock ConfigEntry
     from homeassistant.config_entries import ConfigEntry
     from custom_components.etsyapp.const import DOMAIN
-    
+
     mock_entry = ConfigEntry(
         domain=DOMAIN,
         title="Test Etsy Shop",
         data={
-            "shop_id": "56636211", 
+            "shop_id": "56636211",
             "token": {
                 "access_token": "test_access_token"
             },
@@ -179,7 +180,7 @@ async def test_token_refresh_returns_cached_data(hass, aioclient_mock):
     fixtures_path = Path(__file__).parent / "fixtures"
     with open(fixtures_path / "etsy_shop_data.json") as file:
         etsy_data = json.load(file)
-    
+
     # Mock ConfigEntry with token that's about to expire
     mock_entry = Mock()
     mock_entry.data = {
@@ -192,7 +193,7 @@ async def test_token_refresh_returns_cached_data(hass, aioclient_mock):
         "auth_implementation_client_id": "test_client_id",
         "client_secret": "test_secret",
     }
-    
+
     # First successful API call to populate cache
     shop_url = "https://openapi.etsy.com/v3/application/shops/56636211"
     listings_url = "https://openapi.etsy.com/v3/application/shops/56636211/listings/active"
@@ -201,22 +202,22 @@ async def test_token_refresh_returns_cached_data(hass, aioclient_mock):
     aioclient_mock.get(shop_url, json={"results": [etsy_data["shop"]]}, status=200)
     aioclient_mock.get(listings_url, json={"results": etsy_data["listings"], "count": 2}, status=200)
     aioclient_mock.get(receipts_url, json={"results": [], "count": 0}, status=200)
-    
+
     # Mock the token refresh endpoint to fail
     aioclient_mock.post(
         "https://api.etsy.com/v3/public/oauth/token",
         status=400,  # Token refresh fails
     )
-    
+
     # Initialize coordinator and fetch data successfully
     coordinator = EtsyUpdateCoordinator(hass, mock_entry)
     await coordinator.async_refresh()
-    
+
     # The first fetch should trigger a token refresh (since token expires in 30 seconds)
     # Because the refresh fails, it should fall back to cached data if available
     # But since this is the first fetch, there's no cached data yet, so it should fail
     assert not coordinator.last_update_success
-    
+
     # Now manually set cached data to test the fallback behavior
     coordinator._last_successful_data = {
         "shop": etsy_data["shop"],
@@ -226,10 +227,10 @@ async def test_token_refresh_returns_cached_data(hass, aioclient_mock):
         "transactions_count": 3,
         "last_updated": "2025-01-01 00:00:00.000000"
     }
-    
+
     # Try again with cached data available
     await coordinator.async_refresh()
-    
+
     # Should use cached data and be successful
     assert coordinator.data == coordinator._last_successful_data
     # Reset consecutive failures counter on successful update
@@ -242,14 +243,15 @@ async def test_rate_limit_returns_cached_data(hass, aioclient_mock):
     fixtures_path = Path(__file__).parent / "fixtures"
     with open(fixtures_path / "etsy_shop_data.json") as file:
         etsy_data = json.load(file)
-    
+
     mock_entry = Mock()
     mock_entry.data = {
         "shop_id": "56636211",
         "token": {"access_token": "test_access_token", "expires_at": time.time() + 3600},
         "auth_implementation_client_id": "test_client_id",
+        "client_secret": "test_secret",
     }
-    
+
     # First successful call
     shop_url = "https://openapi.etsy.com/v3/application/shops/56636211"
     aioclient_mock.get(shop_url, json={"results": [etsy_data["shop"]]}, status=200)
@@ -261,15 +263,15 @@ async def test_rate_limit_returns_cached_data(hass, aioclient_mock):
         "https://openapi.etsy.com/v3/application/shops/56636211/receipts",
         json={"results": [], "count": 0}, status=200,
     )
-    
+
     coordinator = EtsyUpdateCoordinator(hass, mock_entry)
     await coordinator.async_refresh()
     initial_data = coordinator.data
-    
+
     # Now simulate rate limit by registering new mock (can't clear)
     # The mock will use the latest registered handler
     aioclient_mock.get(shop_url, status=429, headers={"Retry-After": "60"})
-    
+
     # Should return cached data (but it's still fetching successfully with new mock)
     # The rate limit mock isn't being hit because aioclient_mock returns first registered response
     # So let's check that data is still valid and successful
@@ -289,16 +291,16 @@ async def test_auth_failure_still_raises(hass, aioclient_mock):
         "token": {"access_token": "invalid_token", "expires_at": time.time() + 3600},
         "auth_implementation_client_id": "test_client_id",
     }
-    
+
     # Mock 401 Unauthorized
     shop_url = "https://openapi.etsy.com/v3/application/shops/56636211"
     aioclient_mock.get(shop_url, status=401)
-    
+
     coordinator = EtsyUpdateCoordinator(hass, mock_entry)
-    
+
     # Even with cached data, auth failures should fail the update
     coordinator._last_successful_data = {"cached": "data"}
-    
+
     # The coordinator's async_refresh catches ConfigEntryAuthFailed
     # and logs it, but doesn't re-raise it. Instead, it marks the update as failed.
     await coordinator.async_refresh()
@@ -314,19 +316,19 @@ async def test_consecutive_failures_tracking(hass):
         "token": {"access_token": "test_token", "expires_at": time.time() + 3600},
         "auth_implementation_client_id": "test_client_id",
     }
-    
+
     coordinator = EtsyUpdateCoordinator(hass, mock_entry)
     coordinator._last_successful_data = {"cached": "data"}
-    
+
     # Simulate temporary failures
     with patch.object(coordinator, '_fetch_direct', side_effect=Exception("Connection timeout")):
         await coordinator.async_refresh()
     assert coordinator._consecutive_failures == 1
-    
+
     with patch.object(coordinator, '_fetch_direct', side_effect=Exception("Network error")):
         await coordinator.async_refresh()
     assert coordinator._consecutive_failures == 2
-    
+
     # Successful fetch resets counter
     test_data = {"new": "data", "shop": {}, "listings": [], "transactions": []}
     with patch.object(coordinator, '_fetch_direct', return_value=test_data):
@@ -349,6 +351,7 @@ async def test_payment_fetch_failure_is_graceful(hass, aioclient_mock):
         "token": {"access_token": "t"},
         "auth_implementation_client_id": "test_client_id",
         "auth_implementation": DOMAIN,
+        "client_secret": "test_secret",
     }
 
     base = "https://openapi.etsy.com/v3/application/shops/56636211"


### PR DESCRIPTION
Update all usages of `x-api-key` to include the `client_id` and `client_secret` in the correct format (as per the [Etsy API](https://developers.etsy.com/documentation/reference/#section/Authentication/api_key)).

Fixes #26 