### PR TITLE
fix: attach device triggers via event TRIGGER_SCHEMA so events fire (#28)

### DIFF
--- a/custom_components/etsyapp/device_trigger.py
+++ b/custom_components/etsyapp/device_trigger.py
@@ -94,18 +94,20 @@ async def async_attach_trigger(
     device_id = config[CONF_DEVICE_ID]
     trigger_type = config[CONF_TYPE]
     
-    # Build the event type based on our domain and trigger type
+    # Map the device trigger onto our custom bus event and let the event
+    # trigger platform do the listening. TRIGGER_SCHEMA normalizes the config
+    # (e.g. event_type -> templated list) so async_attach_trigger gets it right.
     event_type = f"{DOMAIN}_{trigger_type}"
-    
-    # Use Home Assistant's event trigger to listen for our custom events
-    event_config = {
-        event_trigger.CONF_PLATFORM: "event",
-        event_trigger.CONF_EVENT_TYPE: event_type,
-        event_trigger.CONF_EVENT_DATA: {
-            CONF_DEVICE_ID: device_id,
-        },
-    }
-    
+    event_config = event_trigger.TRIGGER_SCHEMA(
+        {
+            event_trigger.CONF_PLATFORM: "event",
+            event_trigger.CONF_EVENT_TYPE: event_type,
+            event_trigger.CONF_EVENT_DATA: {
+                CONF_DEVICE_ID: device_id,
+            },
+        }
+    )
+
     # Attach the event trigger
     return await event_trigger.async_attach_trigger(
         hass, event_config, action, trigger_info, platform_type="device"

--- a/tests/test_device_trigger.py
+++ b/tests/test_device_trigger.py
@@ -1,0 +1,69 @@
+"""Test Etsy device triggers."""
+
+import pytest
+
+from custom_components.etsyapp import device_trigger
+from custom_components.etsyapp.const import DOMAIN
+
+
+def _config(device_id: str, trigger_type: str = "new_order") -> dict:
+    return {
+        "platform": "device",
+        "domain": DOMAIN,
+        "device_id": device_id,
+        "type": trigger_type,
+    }
+
+
+@pytest.mark.asyncio
+async def test_attach_trigger_fires_on_matching_event(hass):
+    """async_attach_trigger must subscribe to the real etsyapp_<type> event and
+    invoke the action when the event's device_id matches the configured one."""
+    device_id = "test_device_id"
+    calls = []
+
+    async def action(run_variables, context=None):
+        calls.append(run_variables)
+
+    unsub = await device_trigger.async_attach_trigger(
+        hass, _config(device_id), action, {"trigger_data": {}, "variables": {}}
+    )
+
+    # This is exactly what coordinator._check_for_changes / fire_test_event emit.
+    hass.bus.async_fire(f"{DOMAIN}_new_order", {"device_id": device_id, "new_orders": 1})
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    trigger = calls[0]["trigger"]
+    assert trigger["platform"] == "device"
+    assert trigger["event"].data["new_orders"] == 1
+
+    unsub()
+
+
+@pytest.mark.asyncio
+async def test_attach_trigger_ignores_char_events_and_wrong_device(hass):
+    """Regression for #28: an unvalidated event_type string was iterated
+    character-by-character, so the trigger subscribed to single-letter events
+    (``e``, ``t``, ``s`` ...) instead of ``etsyapp_new_order`` and never fired.
+    Also assert the event_data device_id filter excludes other devices."""
+    device_id = "test_device_id"
+    calls = []
+
+    async def action(run_variables, context=None):
+        calls.append(run_variables)
+
+    unsub = await device_trigger.async_attach_trigger(
+        hass, _config(device_id), action, {"trigger_data": {}, "variables": {}}
+    )
+
+    # Single-letter events (what the char-iteration bug subscribed to) must be ignored.
+    for char in "etsyapp_new_order":
+        hass.bus.async_fire(char, {"device_id": device_id})
+    # A real event for a different device must be filtered out by event_data.
+    hass.bus.async_fire(f"{DOMAIN}_new_order", {"device_id": "other_device"})
+    await hass.async_block_till_done()
+
+    assert calls == []
+
+    unsub()


### PR DESCRIPTION
## Summary

Fixes #28 — `new_order` (and `new_review` / `low_stock`) device triggers never fired.

`async_attach_trigger` in `device_trigger.py` handed a raw dict to the event-trigger platform **without** validating it through `event_trigger.TRIGGER_SCHEMA`. That left `CONF_EVENT_TYPE` as a plain string (`"etsyapp_new_order"`). Home Assistant's event trigger then iterates `event_types` to subscribe listeners — iterating a **string** yields its characters, so it subscribed to bogus single-letter events (`e`, `t`, `s`, `y`, `a`, `p`, `p`, …) and **never** to `etsyapp_new_order`.

That's why the reporter saw the coordinator log `New order detected!` and the `fire_test_event` service log success, yet no automation ever triggered (Traces empty, "Last Triggered: Never") — while "Actions → Run" worked, because it bypasses the trigger.

## Fix

Validate the event config through `event_trigger.TRIGGER_SCHEMA` before attaching — the same pattern HA's own zha/deconz device triggers use. The schema applies `cv.ensure_list` + `[cv.template]`, so `event_type` becomes `['etsyapp_new_order']` and a single correct subscription is made. This fixes all three trigger types; no changes were needed on the event-firing side (coordinator/service payloads and `device_id` were already correct).

## Tests

Added `tests/test_device_trigger.py`:
- **matching event** — attaching the trigger and firing `etsyapp_new_order` with a matching `device_id` invokes the action.
- **regression guard** — single-letter events (`e`, `t`, `s`, …) and events for a different `device_id` do **not** invoke the action.

Confirmed both tests **fail** on the pre-fix code and **pass** with the fix.

```
38 passed in 0.29s
```