### PR TITLE
feat: add pending orders sensor (#24)

### DIFF
--- a/custom_components/etsyapp/const.py
+++ b/custom_components/etsyapp/const.py
@@ -4,6 +4,9 @@ DOMAIN = "etsyapp"
 ETSY_API_BASE = "https://openapi.etsy.com/v3/application"
 UPDATE_INTERVAL_SECONDS = 300  # RATE LIMIT VARIES BY ENDPOINT
 API_FETCH_LIMIT = 10  # Limit for listings and transactions fetched from API
+# Pending-orders (unshipped) fetch: lookback window and page size.
+PENDING_LOOKBACK_DAYS = 365
+PENDING_FETCH_LIMIT = 100  # Etsy per-page max
 
 # Connection modes
 CONNECTION_MODE_DIRECT = "direct"

--- a/custom_components/etsyapp/coordinator.py
+++ b/custom_components/etsyapp/coordinator.py
@@ -21,6 +21,8 @@ from .const import (
     ETSY_API_BASE, 
     UPDATE_INTERVAL_SECONDS,
     API_FETCH_LIMIT,
+    PENDING_LOOKBACK_DAYS,
+    PENDING_FETCH_LIMIT,
     CONNECTION_MODE_DIRECT,
     CONNECTION_MODE_PROXY,
     CONF_CONNECTION_MODE,
@@ -33,6 +35,14 @@ from .utils import build_receipt_summary, build_transaction_detail
 
 _LOGGER = logging.getLogger(__name__)
 type EtsyConfigEntry = ConfigEntry[EtsyUpdateCoordinator]
+
+# Statuses that make an unshipped order non-pending (normalized form).
+_NON_PENDING_STATUSES = frozenset({"canceled", "cancelled", "fully refunded"})
+
+
+def _normalize_status(status: Any) -> str:
+    """Normalize an Etsy receipt status for comparison (lowercase, no underscores)."""
+    return str(status or "").strip().lower().replace("_", " ")
 
 
 class EtsyUpdateCoordinator(DataUpdateCoordinator):
@@ -250,12 +260,17 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
                 transactions_count = len(flattened_transactions)
                 last_payment = await self._fetch_last_payment_proxy(receipts)
 
+            pending_receipts = self._pending_or_last_known(
+                await self._fetch_pending_receipts_proxy()
+            )
+
             proxy_data = {
                 "shop": shop_info,
                 "listings": listings_data.get("results", []),
                 "listings_count": listings_data.get("count", 0),
                 "transactions": flattened_transactions,
                 "receipts": receipts,
+                "pending_receipts": pending_receipts,
                 "last_payment": last_payment,
                 "transactions_count": transactions_count,
                 "last_updated": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
@@ -364,6 +379,95 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
         )
         data["results"] = results
         return data
+
+    @staticmethod
+    def _pending_query_params() -> dict[str, Any]:
+        """Query params for the pending (unshipped) receipts fetch.
+
+        min_created is a day-quantized lookback window.
+        """
+        day = 86400
+        min_created = int(time.time() // day * day) - PENDING_LOOKBACK_DAYS * day
+        return {
+            "limit": PENDING_FETCH_LIMIT,
+            "was_paid": "true",
+            "was_shipped": "false",
+            "was_canceled": "false",
+            "min_created": min_created,
+        }
+
+    @staticmethod
+    def _filter_pending(receipts: list[dict]) -> list[dict]:
+        """Keep unshipped receipts that are still fulfillable (drop shipped,
+        canceled, and fully-refunded orders)."""
+        if len(receipts) >= PENDING_FETCH_LIMIT:
+            _LOGGER.warning(
+                "Pending receipts hit the fetch limit (%s); some open orders "
+                "may be omitted",
+                PENDING_FETCH_LIMIT,
+            )
+        return [
+            r
+            for r in receipts
+            if not r.get("is_shipped")
+            and _normalize_status(r.get("status")) not in _NON_PENDING_STATUSES
+        ]
+
+    async def _fetch_pending_receipts(
+        self, url: str, headers: dict
+    ) -> list[dict] | None:
+        """GET and filter the pending (unshipped) receipts page.
+
+        Returns the filtered list, or None on a transient failure (caller keeps
+        the last-known list). Raises UpdateFailed on 429 to drive backoff.
+        """
+        try:
+            response = await self.session.get(
+                url, headers=headers, params=self._pending_query_params()
+            )
+            if response.status == 429:
+                retry_after = response.headers.get("Retry-After", "60")
+                raise UpdateFailed(
+                    f"Rate limit exceeded (429). Retry after {retry_after} seconds"
+                )
+            if response.status != 200:
+                _LOGGER.debug(
+                    "Pending receipts fetch skipped (status %s)", response.status
+                )
+                return None
+            data = await response.json()
+            return self._filter_pending(data.get("results") or [])
+        except UpdateFailed:
+            raise
+        except Exception as err:  # noqa: BLE001 - secondary fetch, degrade quietly
+            _LOGGER.debug("Pending receipts fetch failed: %s", err)
+            return None
+
+    async def _fetch_pending_receipts_direct(self, headers: dict) -> list[dict] | None:
+        """Fetch unshipped receipts for the pending-orders sensor (direct mode)."""
+        url = f"{ETSY_API_BASE}/shops/{self.shop_id}/receipts"
+        return await self._fetch_pending_receipts(url, headers)
+
+    async def _fetch_pending_receipts_proxy(self) -> list[dict] | None:
+        """Fetch unshipped receipts via proxy (pending-orders sensor)."""
+        path = f"/api/v1/shops/{self.shop_id}/receipts"
+        try:
+            headers = self.hmac_client.get_headers_with_signature(
+                method="GET",
+                path=path,
+                api_key=self.proxy_api_key,
+            )
+        except Exception as err:  # noqa: BLE001 - secondary fetch, degrade quietly
+            _LOGGER.debug("Pending receipts HMAC signing failed: %s", err)
+            return None
+        return await self._fetch_pending_receipts(f"{self.proxy_url}{path}", headers)
+
+    def _pending_or_last_known(self, fetched: list[dict] | None) -> list[dict]:
+        """Return the fetched pending list, or the previous cycle's list when
+        the fetch failed (None). An explicit empty list is kept as-is."""
+        if fetched is not None:
+            return fetched
+        return (self._last_successful_data or {}).get("pending_receipts") or []
 
     async def _fetch_last_payment_proxy(self, receipts: list[dict]) -> dict | None:
         """Fetch the payment for the most recent receipt via proxy. Best-effort."""
@@ -574,12 +678,17 @@ class EtsyUpdateCoordinator(DataUpdateCoordinator):
             # surfaces amount_net.
             last_payment = await self._fetch_last_payment_direct(receipts, headers)
 
+            pending_receipts = self._pending_or_last_known(
+                await self._fetch_pending_receipts_direct(headers)
+            )
+
             # Combine data
             combined_data = {
                 "shop": shop_data,  # Already extracted above
                 "listings": listings_data.get("results", []),
                 "transactions": flattened_transactions,
                 "receipts": receipts,
+                "pending_receipts": pending_receipts,
                 "last_payment": last_payment,
                 "listings_count": listings_data.get("count", 0),
                 "transactions_count": len(flattened_transactions),

--- a/custom_components/etsyapp/manifest.json
+++ b/custom_components/etsyapp/manifest.json
@@ -12,5 +12,5 @@
         "requests>=2.32.3",
         "python-dateutil>=2.9.0"
     ],
-    "version": "1.3.0-beta.2"
+    "version": "1.3.0-beta.3"
 }

--- a/custom_components/etsyapp/sensor.py
+++ b/custom_components/etsyapp/sensor.py
@@ -22,7 +22,7 @@ from .const import (
     EMPTY_ATTRIBUTES,
 )
 from .coordinator import EtsyConfigEntry, EtsyUpdateCoordinator
-from .utils import build_receipt_summary, build_transaction_detail
+from .utils import build_pending_summary, build_receipt_summary, build_transaction_detail
 
 PLATFORMS = [Platform.SENSOR]
 _LOGGER = logging.getLogger(__name__)
@@ -42,6 +42,7 @@ async def async_setup_entry(
             EtsyActiveListings(coordinator),
             EtsyRecentOrders(coordinator),
             EtsyLastOrder(coordinator),
+            EtsyPendingOrders(coordinator),
             EtsyShopStats(coordinator),
         ],
         update_before_add=True,
@@ -365,6 +366,99 @@ class EtsyLastOrder(CoordinatorEntity, SensorEntity):
             "transactions": grouped[most_recent_id],
         }
         return build_receipt_summary(synthetic_receipt)
+
+
+class EtsyPendingOrders(CoordinatorEntity, SensorEntity):
+    """Sensor showing open (paid but unshipped) orders.
+
+    State is the count of pending orders; each order's detail — same shape as
+    sensor.etsy_last_order — is exposed in the ``pending`` attribute so a
+    dashboard can render one card per order via templating (issue #24).
+    """
+
+    def __init__(self, coordinator: EtsyUpdateCoordinator) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._hass_custom_attributes = {"pending": []}
+        self._attr_name = "Etsy Pending Orders"
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_pending_orders"
+        self._globalid = "etsy_pending_orders"
+        self._attr_icon = "mdi:package-variant"
+        self._attr_state = 0
+        # Associate with device
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, coordinator.config_entry.entry_id)},
+        }
+
+    @property
+    def state(self) -> Any:
+        """Return the current state of the sensor."""
+        return self._attr_state
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return self._hass_custom_attributes
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        etsy_data = self.coordinator.data
+        pending = (etsy_data or {}).get("pending_receipts") or []
+
+        if not pending:
+            self._set_empty()
+            return
+
+        # Newest first, consistent with the other order sensors.
+        pending = sorted(
+            pending, key=lambda r: r.get("created_timestamp") or 0, reverse=True
+        )
+        summaries = [build_pending_summary(receipt) for receipt in pending]
+
+        total_quantity = sum(
+            (item.get("quantity") or 1)
+            for summary in summaries
+            for item in summary.get("items", [])
+        )
+        oldest_ts = min(
+            (r.get("created_timestamp") for r in pending if r.get("created_timestamp")),
+            default=None,
+        )
+        oldest_order_date = None
+        if oldest_ts:
+            try:
+                oldest_order_date = datetime.fromtimestamp(int(oldest_ts)).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
+            except (ValueError, TypeError, OSError):
+                oldest_order_date = None
+
+        self._attr_state = len(summaries)
+        self._attr_icon = "mdi:package-variant-closed"
+        self._hass_custom_attributes = {
+            "pending_count": len(summaries),
+            "pending": summaries,
+            "total_quantity": total_quantity,
+            "oldest_order_date": oldest_order_date,
+            "currency_code": summaries[0].get("currency_code", "USD"),
+            "last_updated": (etsy_data or {}).get("last_updated"),
+        }
+        self.async_write_ha_state()
+
+    def _set_empty(self) -> None:
+        # Same attribute keys as the populated case, for stable templates.
+        etsy_data = self.coordinator.data or {}
+        self._attr_state = 0
+        self._attr_icon = "mdi:package-variant"
+        self._hass_custom_attributes = {
+            "pending_count": 0,
+            "pending": [],
+            "total_quantity": 0,
+            "oldest_order_date": None,
+            "currency_code": (etsy_data.get("shop") or {}).get("currency_code", "USD"),
+            "last_updated": etsy_data.get("last_updated"),
+        }
+        self.async_write_ha_state()
 
 
 class EtsyShopStats(CoordinatorEntity, SensorEntity):

--- a/custom_components/etsyapp/utils.py
+++ b/custom_components/etsyapp/utils.py
@@ -165,3 +165,9 @@ def build_receipt_summary(receipt: dict, payment: dict | None = None) -> dict:
             summary["amount_net"] = net["amount"]
 
     return summary
+
+
+def build_pending_summary(receipt: dict) -> dict:
+    """Per-order attribute dict for a pending receipt — same shape as
+    sensor.etsy_last_order (issue #24)."""
+    return build_receipt_summary(receipt)

--- a/tests/test_pending_orders.py
+++ b/tests/test_pending_orders.py
@@ -1,0 +1,259 @@
+"""Tests for the pending-orders (unshipped) feature — issue #24."""
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.etsyapp.const import PENDING_FETCH_LIMIT, PENDING_LOOKBACK_DAYS
+from custom_components.etsyapp.coordinator import EtsyUpdateCoordinator
+from custom_components.etsyapp.sensor import EtsyPendingOrders
+
+
+fixtures_path = Path(__file__).parent / "fixtures"
+with open(fixtures_path / "etsy_receipts_data.json") as file:
+    receipts_fixture = json.load(file)
+
+# Fixture 5550001 is is_shipped=false ("Paid"); 5550002 is is_shipped=true.
+PENDING_RECEIPT = next(
+    r for r in receipts_fixture["receipts"] if not r.get("is_shipped")
+)
+
+
+def _pending_coordinator_data(pending):
+    """Coordinator data dict with a pending_receipts key."""
+    return {
+        "shop": receipts_fixture["shop"],
+        "listings": [],
+        "transactions": [],
+        "receipts": receipts_fixture["receipts"],
+        "pending_receipts": pending,
+        "last_payment": None,
+        "listings_count": 0,
+        "transactions_count": 0,
+        "last_updated": "2025-01-01 00:00:00.000000",
+    }
+
+
+# --- coordinator query params + filter (pure, no HTTP) ---------------------
+
+
+def test_pending_query_params_are_quantized():
+    """min_created is a day-quantized lookback; filter flags are set."""
+    params = EtsyUpdateCoordinator._pending_query_params()
+
+    assert params["was_paid"] == "true"
+    assert params["was_shipped"] == "false"
+    assert params["was_canceled"] == "false"
+    assert params["limit"] == PENDING_FETCH_LIMIT
+
+    min_created = params["min_created"]
+    # Quantized to a day boundary so the proxy cache key stays stable.
+    assert min_created % 86400 == 0
+    expected = int(time.time() // 86400 * 86400) - PENDING_LOOKBACK_DAYS * 86400
+    assert min_created == expected
+
+
+def test_filter_pending_drops_shipped_canceled_refunded():
+    """Keep only unshipped, still-fulfillable receipts. Shipped, canceled, and
+    fully-refunded drop out; a partial refund stays (it can still ship)."""
+    receipts = [
+        {"receipt_id": 1, "is_shipped": False, "status": "Paid"},
+        {"receipt_id": 2, "is_shipped": True, "status": "Completed"},
+        {"receipt_id": 3, "is_shipped": False, "status": "Canceled"},
+        {"receipt_id": 4, "is_shipped": False, "status": "Payment Processing"},
+        {"receipt_id": 5, "is_shipped": False, "status": "Fully Refunded"},
+        {"receipt_id": 6, "is_shipped": False, "status": "fully_refunded"},
+        {"receipt_id": 7, "is_shipped": False, "status": "Partially Refunded"},
+    ]
+    kept = {r["receipt_id"] for r in EtsyUpdateCoordinator._filter_pending(receipts)}
+    assert kept == {1, 4, 7}
+
+
+# --- direct fetch: filtering + graceful degradation ------------------------
+
+
+def _direct_coordinator(hass):
+    mock_entry = Mock()
+    mock_entry.data = {
+        "shop_id": "56636211",
+        "token": {"access_token": "t"},
+        "auth_implementation_client_id": "test_client_id",
+    }
+    return EtsyUpdateCoordinator(hass, mock_entry)
+
+
+@pytest.mark.asyncio
+async def test_fetch_pending_direct_filters_unshipped(hass, aioclient_mock):
+    """A 200 returns only the unshipped receipts, filtered client-side."""
+    coordinator = _direct_coordinator(hass)
+    aioclient_mock.get(
+        "https://openapi.etsy.com/v3/application/shops/56636211/receipts",
+        json={"results": receipts_fixture["receipts"]},
+        status=200,
+    )
+    result = await coordinator._fetch_pending_receipts_direct({"Authorization": "Bearer t"})
+    assert {str(r["receipt_id"]) for r in result} == {str(PENDING_RECEIPT["receipt_id"])}
+
+
+@pytest.mark.asyncio
+async def test_fetch_pending_direct_degrades_to_none(hass, aioclient_mock):
+    """A non-200 returns None rather than an empty list."""
+    coordinator = _direct_coordinator(hass)
+    aioclient_mock.get(
+        "https://openapi.etsy.com/v3/application/shops/56636211/receipts",
+        status=500,
+    )
+    result = await coordinator._fetch_pending_receipts_direct({"Authorization": "Bearer t"})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_pending_direct_raises_on_rate_limit(hass, aioclient_mock):
+    """429 raises UpdateFailed (drives the coordinator's backoff)."""
+    coordinator = _direct_coordinator(hass)
+    aioclient_mock.get(
+        "https://openapi.etsy.com/v3/application/shops/56636211/receipts",
+        status=429,
+        headers={"Retry-After": "30"},
+    )
+    with pytest.raises(UpdateFailed):
+        await coordinator._fetch_pending_receipts_direct({"Authorization": "Bearer t"})
+
+
+@pytest.mark.asyncio
+async def test_pending_falls_back_to_last_known(hass):
+    """A failed fetch (None) reuses the prior cycle's list; an empty list stays empty."""
+    coordinator = _direct_coordinator(hass)
+    coordinator._last_successful_data = {"pending_receipts": [{"receipt_id": 9}]}
+    assert coordinator._pending_or_last_known(None) == [{"receipt_id": 9}]
+    assert coordinator._pending_or_last_known([]) == []
+
+
+@pytest.mark.asyncio
+async def test_direct_refresh_populates_pending(hass, aioclient_mock):
+    """End-to-end direct-mode refresh adds pending_receipts without disturbing
+    the existing keys (non-breaking)."""
+    mock_entry = Mock()
+    mock_entry.data = {
+        "shop_id": "56636211",
+        "token": {"access_token": "test_access_token"},
+        "auth_implementation_client_id": "test_client_id",
+        "auth_implementation": "etsyapp",
+    }
+    base = "https://openapi.etsy.com/v3/application/shops/56636211"
+    aioclient_mock.get(base, json={"results": [receipts_fixture["shop"]]}, status=200)
+    aioclient_mock.get(
+        f"{base}/listings/active",
+        json={
+            "results": receipts_fixture["listings"],
+            "count": len(receipts_fixture["listings"]),
+        },
+        status=200,
+    )
+    aioclient_mock.get(
+        f"{base}/receipts",
+        json={
+            "results": receipts_fixture["receipts"],
+            "count": len(receipts_fixture["receipts"]),
+        },
+        status=200,
+    )
+    aioclient_mock.get(
+        f"{base}/receipts/{PENDING_RECEIPT['receipt_id']}/payments",
+        json={"results": [receipts_fixture["last_payment"]]},
+        status=200,
+    )
+
+    coordinator = EtsyUpdateCoordinator(hass, mock_entry)
+    coordinator._oauth_session_initialized = True
+    mock_oauth = AsyncMock()
+    mock_oauth.async_ensure_token_valid = AsyncMock()
+    mock_oauth.token = {"access_token": "test_access_token"}
+    coordinator.oauth_session = mock_oauth
+
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    # New additive key, filtered to the unshipped receipt only.
+    assert {str(r["receipt_id"]) for r in coordinator.data["pending_receipts"]} == {
+        str(PENDING_RECEIPT["receipt_id"])
+    }
+    # Existing keys unchanged.
+    assert coordinator.data["transactions_count"] == 3
+    assert len(coordinator.data["receipts"]) == 2
+
+    # The pending fetch reached the wire with its distinct filter params.
+    receipts_calls = [
+        call for call in aioclient_mock.mock_calls
+        if call[1].path.endswith("/shops/56636211/receipts")
+    ]
+    pending_calls = [
+        call for call in receipts_calls
+        if call[1].query.get("was_shipped") == "false"
+    ]
+    assert len(pending_calls) == 1
+    pending_query = pending_calls[0][1].query
+    assert pending_query.get("was_canceled") == "false"
+    assert "min_created" in pending_query
+
+
+# --- sensor ----------------------------------------------------------------
+
+
+def _sensor(data):
+    coordinator = AsyncMock(spec=EtsyUpdateCoordinator)
+    coordinator.data = data
+    coordinator.config_entry = AsyncMock()
+    coordinator.config_entry.entry_id = "test_entry_id"
+    coordinator.config_entry.options = {}
+    sensor = EtsyPendingOrders(coordinator)
+    sensor.async_write_ha_state = Mock()
+    return sensor
+
+
+@pytest.mark.asyncio
+async def test_pending_orders_sensor():
+    """State is the pending count; attributes carry per-order detail."""
+    sensor = _sensor(_pending_coordinator_data([PENDING_RECEIPT]))
+    sensor._handle_coordinator_update()
+
+    assert sensor.state == 1
+    attrs = sensor.extra_state_attributes
+    assert attrs["pending_count"] == 1
+    assert len(attrs["pending"]) == 1
+    # Same per-order shape as sensor.etsy_last_order (issue #24 requirement).
+    order = attrs["pending"][0]
+    assert order["receipt_id"] == str(PENDING_RECEIPT["receipt_id"])
+    assert order["buyer_name"] == "Jane Doe"
+    assert order["is_shipped"] is False
+    assert order["item_count"] == 2
+    # 1 wallet + 2 keychains
+    assert attrs["total_quantity"] == 3
+    assert attrs["currency_code"] == "USD"
+    assert sensor._attr_icon == "mdi:package-variant-closed"
+
+
+@pytest.mark.asyncio
+async def test_pending_orders_sensor_empty():
+    """No pending orders → state 0 and an empty list."""
+    sensor = _sensor(_pending_coordinator_data([]))
+    sensor._handle_coordinator_update()
+
+    assert sensor.state == 0
+    assert sensor.extra_state_attributes["pending"] == []
+    assert sensor._attr_icon == "mdi:package-variant"
+
+
+@pytest.mark.asyncio
+async def test_pending_orders_sensor_no_data():
+    """No coordinator data at all → empty, no error."""
+    sensor = _sensor(None)
+    sensor._handle_coordinator_update()
+
+    assert sensor.state == 0
+    assert sensor.extra_state_attributes["pending"] == []

--- a/tests/test_pending_orders.py
+++ b/tests/test_pending_orders.py
@@ -144,6 +144,7 @@ async def test_direct_refresh_populates_pending(hass, aioclient_mock):
         "token": {"access_token": "test_access_token"},
         "auth_implementation_client_id": "test_client_id",
         "auth_implementation": "etsyapp",
+        "client_secret": "test_secret",
     }
     base = "https://openapi.etsy.com/v3/application/shops/56636211"
     aioclient_mock.get(base, json={"results": [receipts_fixture["shop"]]}, status=200)


### PR DESCRIPTION
## Summary

Adds `sensor.etsy_pending_orders` for issue #24 — a single aggregate sensor for open (paid but unshipped) Etsy orders, so users can build a unified order dashboard.

- **State** = count of open orders.
- **Attributes**: `pending_count`, `total_quantity`, `oldest_order_date`, `currency_code`, `last_updated`, and `pending[]` — one object per order with the **same shape as `sensor.etsy_last_order`** (receipt_id, status, buyer_name, order_total, item_count, items, …), so dashboards can template one card per order.

## How it works

The coordinator adds a separate pending fetch (`was_paid=true` + `was_shipped=false` + `was_canceled=false` + a day-quantized `min_created` lookback) stored under a **new** `pending_receipts` key. A `was_shipped=false` filter alone returns old/canceled receipts, so the lookback window bounds it, and shipped/canceled/fully-refunded orders are filtered out client-side (partial refunds stay — still shippable).

## Non-breaking

Purely additive — the existing `was_paid=true` receipts query and the `receipts` / `transactions` / `transactions_count` keys are untouched, so `EtsyLastOrder`, `EtsyRecentOrders`, and `EtsyShopStats` are unaffected. New sensor only; no new OAuth scope. Minor version bump (`1.3.0-beta.2` → `1.3.0-beta.3`).

## Resilience

- Transient pending-fetch failure → keeps the **last-known** list (no false zero that could trip "all shipped" automations).
- 429 → raises `UpdateFailed` so the coordinator's existing backoff engages.
- Empty and populated states expose the **same attribute keys** for stable templates.

## Proxy dependency

Proxy mode depends on a companion change adding `min_created`/`max_created` to the proxy's `/receipts` route (separate PR, merges/deploys first). Direct mode works standalone; proxy mode degrades to last-known/empty against an un-upgraded proxy.

## Tests

New `tests/test_pending_orders.py` (query params, filtering incl. refunded, direct fetch + degradation + 429, last-known fallback, direct-refresh end-to-end asserting the pending query hits the wire, sensor states). Full suite: **46 passed**.